### PR TITLE
Use ServiceDefaults from GitHub Packages instead of project reference

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore Maliev.AuthService.sln
+        env:
+          NUGET_USERNAME: ${{ github.actor }}
+          NUGET_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: dotnet build Maliev.AuthService.sln --no-restore
@@ -89,9 +92,4 @@ jobs:
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
-          gh pr create \
-            --title "Deploy auth-service ${{ github.sha }} to development" \
-            --body "$PR_BODY" \
-            --base main \
-            --head $BRANCH_NAME \
-            --repo MALIEV-Co-Ltd/maliev-gitops
+          gh pr create             --title "Deploy auth-service ${{ github.sha }} to development"             --body "$PR_BODY"             --base main             --head $BRANCH_NAME             --repo MALIEV-Co-Ltd/maliev-gitops

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore Maliev.AuthService.sln
+        env:
+          NUGET_USERNAME: ${{ github.actor }}
+          NUGET_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: dotnet build Maliev.AuthService.sln --no-restore
@@ -67,7 +70,7 @@ jobs:
           PR_BODY: |
             Automated deployment of auth-service to production environment.
 
-            ⚠️ **PRODUCTION DEPLOYMENT** - Please review carefully before merging.
+            **PRODUCTION DEPLOYMENT** - Please review carefully before merging.
 
             Commit: ${{ github.sha }}
             Triggered by: ${{ github.actor }}
@@ -92,9 +95,4 @@ jobs:
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
-          gh pr create \
-            --title "Deploy auth-service ${{ github.sha }} to production" \
-            --body "$PR_BODY" \
-            --base main \
-            --head $BRANCH_NAME \
-            --repo MALIEV-Co-Ltd/maliev-gitops
+          gh pr create             --title "Deploy auth-service ${{ github.sha }} to production"             --body "$PR_BODY"             --base main             --head $BRANCH_NAME             --repo MALIEV-Co-Ltd/maliev-gitops

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore Maliev.AuthService.sln
+        env:
+          NUGET_USERNAME: ${{ github.actor }}
+          NUGET_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: dotnet build Maliev.AuthService.sln --no-restore
@@ -96,9 +99,4 @@ jobs:
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
-          gh pr create \
-            --title "Deploy auth-service $RELEASE_VERSION to staging" \
-            --body "$PR_BODY" \
-            --base main \
-            --head $BRANCH_NAME \
-            --repo MALIEV-Co-Ltd/maliev-gitops
+          gh pr create             --title "Deploy auth-service $RELEASE_VERSION to staging"             --body "$PR_BODY"             --base main             --head $BRANCH_NAME             --repo MALIEV-Co-Ltd/maliev-gitops

--- a/Maliev.AuthService.Api/Maliev.AuthService.Api.csproj
+++ b/Maliev.AuthService.Api/Maliev.AuthService.Api.csproj
@@ -25,11 +25,12 @@
     <PackageReference Include="Scalar.AspNetCore" Version="1.2.42" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.9.25" />
+    <!-- Aspire ServiceDefaults from GitHub Packages -->
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="1.0.*" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Maliev.AuthService.Data\Maliev.AuthService.Data.csproj" />
-    <ProjectReference Include="..\..\Maliev.Aspire\Maliev.Aspire.ServiceDefaults\Maliev.Aspire.ServiceDefaults.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="github" value="https://nuget.pkg.github.com/MALIEV-Co-Ltd/index.json" />
+  </packageSources>
+
+  <packageSourceCredentials>
+    <github>
+      <add key="Username" value="%NUGET_USERNAME%" />
+      <add key="ClearTextPassword" value="%NUGET_PASSWORD%" />
+    </github>
+  </packageSourceCredentials>
+</configuration>


### PR DESCRIPTION
## Summary

- Replace project reference to `Maliev.Aspire.ServiceDefaults` with NuGet package reference from GitHub Packages
- Add `nuget.config` pointing to GitHub Packages feed with authentication
- Update CI workflows to authenticate with GitHub Packages during restore

## Changes

- **Maliev.AuthService.Api.csproj**: Replace `ProjectReference` with `PackageReference Include="Maliev.Aspire.ServiceDefaults"`
- **nuget.config**: New file configuring GitHub Packages as a NuGet source
- **ci-develop.yml, ci-staging.yml, ci-main.yml**: Add `NUGET_USERNAME` and `NUGET_PASSWORD` env vars to restore step

## Why

The previous project reference `..\..\Maliev.Aspire\...` fails in CI because each microservice is in its own repository. Using a NuGet package from GitHub Packages allows CI to restore dependencies correctly.

## Dependencies

This PR requires the ServiceDefaults package to be published first:
- https://github.com/MALIEV-Co-Ltd/Maliev.Aspire/pull/2

## Test plan

- [ ] Merge Aspire PR first to publish the package
- [ ] Verify CI workflow can restore dependencies
- [ ] Verify build and tests pass