### PR TITLE
Fix: Use GITOPS_PAT for cross-repo GitHub Packages authentication

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -22,7 +22,7 @@ jobs:
         run: dotnet restore Maliev.AuthService.sln
         env:
           NUGET_USERNAME: ${{ github.actor }}
-          NUGET_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_PASSWORD: ${{ secrets.GITOPS_PAT }}
 
       - name: Build
         run: dotnet build Maliev.AuthService.sln --no-restore

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -22,7 +22,7 @@ jobs:
         run: dotnet restore Maliev.AuthService.sln
         env:
           NUGET_USERNAME: ${{ github.actor }}
-          NUGET_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_PASSWORD: ${{ secrets.GITOPS_PAT }}
 
       - name: Build
         run: dotnet build Maliev.AuthService.sln --no-restore

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -22,7 +22,7 @@ jobs:
         run: dotnet restore Maliev.AuthService.sln
         env:
           NUGET_USERNAME: ${{ github.actor }}
-          NUGET_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_PASSWORD: ${{ secrets.GITOPS_PAT }}
 
       - name: Build
         run: dotnet build Maliev.AuthService.sln --no-restore


### PR DESCRIPTION
GITHUB_TOKEN cannot access packages from other repositories. GITOPS_PAT has cross-repo permissions needed for GitHub Packages.