### PR TITLE
Fix Docker build to authenticate with GitHub Packages

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build and push Docker image
         run: |
           gcloud auth configure-docker asia-southeast1-docker.pkg.dev
-          docker build -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-dev/maliev-auth-service:${{ github.sha }} -f Maliev.AuthService.Api/Dockerfile .
+          docker build --build-arg NUGET_USERNAME=${{ github.actor }} --build-arg NUGET_PASSWORD=${{ secrets.GITOPS_PAT }} -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-dev/maliev-auth-service:${{ github.sha }} -f Maliev.AuthService.Api/Dockerfile .
           docker push asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-dev/maliev-auth-service:${{ github.sha }}
 
       - name: Checkout maliev-gitops repository

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build and push Docker image
         run: |
           gcloud auth configure-docker asia-southeast1-docker.pkg.dev
-          docker build -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-prod/maliev-auth-service:${{ github.sha }} -f Maliev.AuthService.Api/Dockerfile .
+          docker build --build-arg NUGET_USERNAME=${{ github.actor }} --build-arg NUGET_PASSWORD=${{ secrets.GITOPS_PAT }} -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-prod/maliev-auth-service:${{ github.sha }} -f Maliev.AuthService.Api/Dockerfile .
           docker push asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-prod/maliev-auth-service:${{ github.sha }}
 
       - name: Checkout maliev-gitops repository

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           gcloud auth configure-docker asia-southeast1-docker.pkg.dev
           export RELEASE_VERSION=$(echo ${{ github.ref }} | sed -e 's,.*/v,,g')
-          docker build -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-staging/maliev-auth-service:$RELEASE_VERSION -f Maliev.AuthService.Api/Dockerfile .
+          docker build --build-arg NUGET_USERNAME=${{ github.actor }} --build-arg NUGET_PASSWORD=${{ secrets.GITOPS_PAT }} -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-staging/maliev-auth-service:$RELEASE_VERSION -f Maliev.AuthService.Api/Dockerfile .
           docker push asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-staging/maliev-auth-service:$RELEASE_VERSION
 
       - name: Checkout maliev-gitops repository

--- a/Maliev.AuthService.Api/Dockerfile
+++ b/Maliev.AuthService.Api/Dockerfile
@@ -11,10 +11,18 @@ EXPOSE 8081
 # This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
+ARG NUGET_USERNAME
+ARG NUGET_PASSWORD
 WORKDIR /src
+
+# Copy nuget.config and project files
+COPY ["nuget.config", "."]
 COPY ["Maliev.AuthService.Api/Maliev.AuthService.Api.csproj", "Maliev.AuthService.Api/"]
 COPY ["Maliev.AuthService.Data/Maliev.AuthService.Data.csproj", "Maliev.AuthService.Data/"]
+
+# Restore with GitHub Packages authentication
 RUN dotnet restore "./Maliev.AuthService.Api/Maliev.AuthService.Api.csproj"
+
 COPY . .
 WORKDIR "/src/Maliev.AuthService.Api"
 RUN dotnet build "./Maliev.AuthService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build


### PR DESCRIPTION
- Update Dockerfile to copy nuget.config and accept NUGET credentials as build args
- Update CI workflows to pass NUGET_USERNAME and NUGET_PASSWORD to docker build

This fixes the "Unable to find package Maliev.Aspire.ServiceDefaults" error during Docker build.