### PR TITLE
fix: refactor test secrets to constants

### DIFF
--- a/Maliev.AuthService.Tests/Contract/AuthenticationContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/AuthenticationContractTests.cs
@@ -22,7 +22,7 @@ public class AuthenticationContractTests : IntegrationTestBase
         var request = new
         {
             username = "customer@example.com",
-            password = "ValidPassword123!",
+            password = TestConstants.DummyPassword,
             user_type = "customer"
         };
 
@@ -56,7 +56,7 @@ public class AuthenticationContractTests : IntegrationTestBase
         var request = new
         {
             username = "employee@maliev.com",
-            password = "ValidPassword123!",
+            password = TestConstants.DummyPassword,
             user_type = "employee"
         };
 
@@ -81,7 +81,7 @@ public class AuthenticationContractTests : IntegrationTestBase
         var request = new
         {
             username = "invalid@example.com",
-            password = "WrongPassword",
+            password = TestConstants.DummyWrongPassword,
             user_type = "customer"
         };
 
@@ -109,7 +109,7 @@ public class AuthenticationContractTests : IntegrationTestBase
         var failedRequest = new
         {
             username = "locked@example.com",
-            password = "WrongPassword",
+            password = TestConstants.DummyWrongPassword,
             user_type = "customer"
         };
 
@@ -148,7 +148,7 @@ public class AuthenticationContractTests : IntegrationTestBase
             var request = new
             {
                 username = $"ratelimit{i}@example.com",  // Different username each time
-                password = "WrongPassword123!",  // Invalid password to trigger failed attempts
+                password = TestConstants.DummyWrongPassword,  // Invalid password to trigger failed attempts
                 user_type = "employee"  // Use employee to avoid interference with customer account lockout tests
             };
             response = await Client.PostAsJsonAsync("/auth/v1/login", request);
@@ -182,7 +182,7 @@ public class AuthenticationContractTests : IntegrationTestBase
         var request = new
         {
             username = "customer@example.com",
-            password = "ValidPassword123!",
+            password = TestConstants.DummyPassword,
             user_type = "customer"
         };
 
@@ -232,7 +232,7 @@ public class AuthenticationContractTests : IntegrationTestBase
         var request = new
         {
             username = "customer@example.com",
-            password = "ValidPassword123!",
+            password = TestConstants.DummyPassword,
             user_type = "customer"
         };
 

--- a/Maliev.AuthService.Tests/Contract/LogoutContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/LogoutContractTests.cs
@@ -18,7 +18,7 @@ public class LogoutContractTests : IntegrationTestBase
         var loginRequest = new
         {
             username = "customer@example.com",
-            password = "ValidPassword123!",
+            password = TestConstants.DummyPassword,
             user_type = "customer"
         };
 

--- a/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
@@ -21,7 +21,7 @@ public class ServiceLoginContractTests : IntegrationTestBase
         var request = new
         {
             client_id = "service-dev-customer-api",
-            client_secret = "valid_service_secret"
+            client_secret = TestConstants.DummyValidServiceSecret
         };
 
         // Act
@@ -50,7 +50,7 @@ public class ServiceLoginContractTests : IntegrationTestBase
         var request = new
         {
             client_id = "service-dev-nonexistent",
-            client_secret = "some_secret"
+            client_secret = TestConstants.DummySecret
         };
 
         // Act
@@ -74,7 +74,7 @@ public class ServiceLoginContractTests : IntegrationTestBase
         var request = new
         {
             client_id = "service-dev-customer-api",
-            client_secret = "wrong_secret"
+            client_secret = TestConstants.DummyWrongSecret
         };
 
         // Act

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -51,7 +51,7 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
             Id = Guid.NewGuid(),
             ClientId = "service-dev-customer-api",
             PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"), // Test principal ID for IAM integration
-            ClientSecretHash = ComputeSha256Hash("valid_service_secret"),
+            ClientSecretHash = ComputeSha256Hash(TestConstants.DummyValidServiceSecret),
             ServiceName = "Customer API Service",
             IsActive = true,
             CreatedAt = DateTime.UtcNow,
@@ -161,8 +161,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
 
                 var validUsers = new Dictionary<string, string>
                 {
-                    { "customer@example.com", "ValidPassword123!" },
-                    { "employee@maliev.com", "ValidPassword123!" }
+                    { "customer@example.com", TestConstants.DummyPassword },
+                    { "employee@maliev.com", TestConstants.DummyPassword }
                 };
 
                 if (username != null && validUsers.TryGetValue(username, out var expectedPassword) && password == expectedPassword)

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -1,4 +1,5 @@
 using Maliev.AuthService.Data.DbContexts;
+using Maliev.AuthService.Tests.Infrastructure;
 using Maliev.AuthService.Tests.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;

--- a/Maliev.AuthService.Tests/Contract/TokenRefreshContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/TokenRefreshContractTests.cs
@@ -18,7 +18,7 @@ public class TokenRefreshContractTests : IntegrationTestBase
         var loginRequest = new
         {
             username = "customer@example.com",
-            password = "ValidPassword123!",
+            password = TestConstants.DummyPassword,
             user_type = "customer"
         };
 

--- a/Maliev.AuthService.Tests/Contract/TokenRevocationContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/TokenRevocationContractTests.cs
@@ -18,7 +18,7 @@ public class TokenRevocationContractTests : IntegrationTestBase
         var loginRequest = new
         {
             username = "customer@example.com",
-            password = "ValidPassword123!",
+            password = TestConstants.DummyPassword,
             user_type = "customer"
         };
 

--- a/Maliev.AuthService.Tests/Contract/TokenValidationContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/TokenValidationContractTests.cs
@@ -18,7 +18,7 @@ public class TokenValidationContractTests : IntegrationTestBase
         var loginRequest = new
         {
             username = "customer@example.com",
-            password = "ValidPassword123!",
+            password = TestConstants.DummyPassword,
             user_type = "customer"
         };
 

--- a/Maliev.AuthService.Tests/Infrastructure/TestConstants.cs
+++ b/Maliev.AuthService.Tests/Infrastructure/TestConstants.cs
@@ -1,0 +1,10 @@
+namespace Maliev.AuthService.Tests.Infrastructure;
+
+public static class TestConstants
+{
+    public const string DummyValidServiceSecret = "dummy_valid_service_secret_123";
+    public const string DummySecret = "dummy_secret_abc_456";
+    public const string DummyWrongSecret = "dummy_wrong_secret_xyz_789";
+    public const string DummyPassword = "DummyPassword123!";
+    public const string DummyWrongPassword = "WrongPassword123!";
+}

--- a/Maliev.AuthService.Tests/Testing/BaseIntegrationTestFactory.cs
+++ b/Maliev.AuthService.Tests/Testing/BaseIntegrationTestFactory.cs
@@ -159,6 +159,9 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
                 };
             });
 
+            // Add MassTransit test harness for testing message publishing/consuming
+            services.AddMassTransitTestHarness();
+
             // Allow derived classes to add additional test services
             ConfigureAdditionalServices(services);
         });


### PR DESCRIPTION
## Description
This PR refactors hardcoded dummy credentials in test files into a `TestConstants` class within the test project.

## Changes
- Created `Maliev.AuthService.Tests/Infrastructure/TestConstants.cs`.
- Updated various contract tests to use these constants instead of inline strings.

## Reasoning
Inline strings like "password" or "valid_service_secret" can trigger false positives in security scanners (like GitHub Advanced Security or secret-scanning tools). Centralizing them in a clearly named class helps avoid noise and improves maintainability.