### PR TITLE
fix: align employee lookup with EmployeeService API contract

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,9 +16,9 @@ jobs:
       - id: set-version
         run: |
           BASE_BRANCH="${{ github.base_ref }}"
-          if ["$BASE_BRANCH" == "main"]; then
+          if ["$BASE_BRANCH" == "main" ]; then
             VERSION_FORMAT="1.0.*"
-          elif ["$BASE_BRANCH" == "staging"]; then
+          elif ["$BASE_BRANCH" == "staging" ]; then
             VERSION_FORMAT="1.0.*-beta*"
           else
             VERSION_FORMAT="1.0.*-alpha*"

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,279 +1,93 @@
-# MALIEV Microservices Constitution
+# MALIEV Microservices Constitution (v2.0.0)
 
-## Core Principles
-
-### I. Service Autonomy (NON-NEGOTIABLE)
-
-Each microservice must be **self-contained**:
-
-* Own database and schema
-* Own domain logic
-* Interact with others only via APIs or events
-* No direct database access to another service
-
-**Rationale:** Enables independent deployment, scaling, and ownership.
+This is the foundational law of the MALIEV platform. All services, developers, and agents MUST adhere to these rules.
 
 ---
 
-### II. Explicit Contracts
+## 🏗️ 1. Technical Architecture & Frameworks
 
-* All APIs documented via **OpenAPI/Scalar**
-* Data contracts versioned (MAJOR.MINOR)
-* Backward-compatible migrations mandatory
+### I. Framework Standards
+*   **Target Framework**: All C# services MUST target **.NET 10** (and EF Core 10).
+*   **Infrastructure**: Standard stack includes **PostgreSQL** (via CloudNativePG), **RabbitMQ** (via MassTransit), and **Redis** (caching).
+*   **Optimization**: Codebase must be optimized for **minimal resource usage** (e.g., memory-efficient pooling, trimmed images).
 
-**Rationale:** Prevents breaking changes and preserves consumer stability. Scalar provides a more modern and performant API documentation experience.
+### II. ServiceDefaults & Aspire
+*   **Shared Infrastructure**: Every service MUST fully utilize `Maliev.Aspire.ServiceDefaults`. Manual configuration of OpenTelemetry, health checks, or resilience is prohibited.
+*   **Local Orchestration**: Services must be integrated into the `Maliev.Aspire` project for local development.
 
----
-
-### III. Test-First Development (NON-NEGOTIABLE)
-
-* Tests authored **immediately after specification approval**, before implementation
-* Code must **fail tests first** (Red–Green–Refactor)
-* Unit, integration, and contract tests mandatory
-* Minimum 80 % coverage for business-critical logic
-* Test code reviewed equally with production code
-
-**Rationale:** Ensures correctness before coding and keeps system behavior verifiable.
+### III. Solutions & Projects
+*   **Solution Format**: Prefer **.slnx** over the traditional `.sln`.
+*   **No Boilerplate**: Absolute prohibition of default template code (e.g., `Class1.cs`, `WeatherForecast.cs`, `UnitTest1.cs`). Delete them immediately.
 
 ---
 
-### IV. Real Infrastructure Testing (NON-NEGOTIABLE)
+## 📡 2. API & Communication
 
-* **ALL tests MUST use real infrastructure dependencies** via Testcontainers - no in-memory substitutes allowed
-* **PostgreSQL**: Real PostgreSQL instances required (no EF Core InMemoryDatabase provider permitted)
-* **RabbitMQ**: Real RabbitMQ instances required for message queue testing (no in-memory message buses)
-* **Redis**: Real Redis instances required for caching and distributed locking tests (no in-memory cache providers)
-* Integration tests MUST use Docker containers for all infrastructure (local/CI)
-* Test isolation achieved through database transactions, queue purging, or cleanup scripts
-* Test infrastructure must mirror production configuration exactly (same versions, same settings)
+### IV. Routing & Versioning
+*   **Service Prefix**: All routes MUST be prefixed with the service domain (e.g., `/auth`, `/customer`, `/job`).
+*   **Versioning**: All API routes MUST be versioned (e.g., `/auth/v1/...`).
+*   **launchSettings**: `launchSettings.json` MUST be configured to automatically launch the **Scalar** documentation page.
 
-**Rationale:** In-memory substitutes have different behavior, concurrency handling, and constraints than real infrastructure. Testing against production-like infrastructure catches real-world issues early (distributed locking race conditions, message serialization, connection pooling, transaction isolation) and eliminates false positives from in-memory quirks. This ensures test fidelity and production confidence across all infrastructure layers.
+### V. Documentation
+*   **Scalar UI**: Use **Scalar** instead of Swagger for API documentation. Swagger/Swashbuckle packages are BANNED.
+*   **XML Documentation**: Mandatory XML comments on all public methods, properties, and classes.
 
----
-
-### V. Auditability & Observability
-
-* Structured JSON logging with traceable user/action IDs
-* Immutable audit logs retained per policy
-* Health checks for liveness/readiness
-* **Mandatory Log Level Configuration**: `appsettings.json` MUST use the following LogLevel configuration to reduce noise:
-  ```json
-  "LogLevel": {
-    "Default": "Information",
-    "Microsoft.AspNetCore": "Warning",
-    "Microsoft.EntityFrameworkCore": "Warning",
-    "Microsoft.AspNetCore.Watch.BrowserRefresh": "None",
-    "Microsoft.Hosting.Lifetime": "Information",
-    "Microsoft.AspNetCore.Watch": "Warning",
-    "System": "Warning"
-  }
-  ```
-
-**Rationale:** Enables compliance, diagnostics, and operational insight.
+### VI. Messaging
+*   **Centralized Contracts**: All inter-service events MUST reside in `Maliev.MessagingContracts`. Local events are prohibited for inter-service communication.
 
 ---
 
-### VI. Security & Compliance
+## 🔒 3. Security & Authorization
 
-* JWT authentication, role-based authorization
-* Sensitive data encrypted at rest and in transit
-* Compliance with GDPR, Thai tax law, and all relevant regulations
+### VII. Permission System
+*   **GCP-Style Permissions**: Use resource-scoped permissions (e.g., `auth.tokens.revoke`, `job.jobs.read`).
+*   **Implementation**: Permissions must be defined as `static const string` and enforced using the custom `[RequirePermission]` attribute (not plain `[Authorize]`).
 
----
-
-### VII. Secrets Management & Configuration Security (NON-NEGOTIABLE)
-
-* No secrets in source code
-* Secrets injected from **Google Secret Manager**
-* Public repositories sanitized of real endpoints
-* Commits scanned for secrets before merge
-
-**Rationale:** Prevents leaks and targeted attacks.
+### VIII. Secrets & Credentials
+*   **Zero Secrets**: Absolute prohibition of secrets in the entire codebase. No hardcoded keys, passwords, or connection strings.
+*   **Environment Injection**: Use Google Cloud's **External Secrets Operator (ESO)** for production secrets.
+*   **NuGet Feed**: Connection to the private NuGet feed (for ServiceDefaults/Contracts) MUST use environment-variable-based credentials.
 
 ---
 
-### VIII. Zero Warnings Policy (NON-NEGOTIABLE)
+## 🛠️ 4. Development & Workflow
 
-* Builds must emit zero warnings
-* Warnings treated as build failures
+### IX. Version Control
+*   **Feature Branches**: Use a feature-branch-oriented workflow. Development should happen on feature branches, issued into a PR for merge into `develop`.
+*   **LLM Metadata**: Committing `.claude`, `.gemini`, `.opencode`, `.specify`, etc., is allowed and encouraged.
+*   **Exclusions**: Never commit developer-specific settings (e.g., `*.local.json`, `.env`).
 
-**Rationale:** Eliminates technical debt and instability.
+### X. Code Quality
+*   **TreatWarningsAsErrors**: Mandatory. All warnings must be resolved correctly; suppression is prohibited.
+*   **Banned Libraries**: Strictly no **Swagger/Swashbuckle**, **FluentAssertions**, or **FluentValidation**.
+*   **Pre-commit**: Use `.pre-commit-config.yaml` for local linting and verification.
 
----
-
-### IX. Clean Project Artifacts (NON-NEGOTIABLE)
-
-* Remove unused files, outdated docs, and generated artifacts
-* `.gitignore` must exclude temporary files
-* `.dockerignore` must exclude build artifacts, specs, and IDE files
-* Cleanup enforced pre-release
-* **NO additional markdown documents** in the repository root (e.g., `COMPLIANCE_REVIEW.md` is forbidden). Only `README.md`, `LICENSE` are allowed.
-* **CODEOWNERS** file is MANDATORY at `.github/CODEOWNERS` with content: `* @MALIEV-Co-Ltd/core-developers`
-
----
-
-### X. Docker Best Practices (NON-NEGOTIABLE)
-
-* **The Dockerfile MUST be located in the API project folder** (e.g., `Maliev.UploadService.Api/Dockerfile`), NOT at the repository root.
-* **ALL services MUST use the built-in `app` user** from Microsoft's ASP.NET runtime images
-* **NO custom user creation** with `useradd`, `adduser`, or `addgroup` commands
-* Multi-stage builds mandatory: SDK for build, ASP.NET runtime for final image
-* Use .NET 10 base images: `mcr.microsoft.com/dotnet/sdk:10.0` and `mcr.microsoft.com/dotnet/aspnet:10.0`
-* Set ownership with `chown -R app:app /app` **BEFORE** the `USER app` directive, then COPY files as `app` user
-* Use `.dockerignore` to exclude build outputs, IDE files, specs, CI/CD files, **and Test projects**
-* BuildKit secrets mandatory for NuGet credentials: `--mount=type=secret,id=nuget_username`
-* Health checks must validate service liveness endpoint: `HEALTHCHECK CMD curl -f http://localhost:8080/[service-name]/liveness || exit 1`
-* Optimize layer caching by copying project files before source code
-* Expose port 8080: `EXPOSE 8080` and `ENV ASPNETCORE_URLS=http://+:8080`
-
-**Standard Dockerfile Pattern:**
-
-```dockerfile
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
-WORKDIR /
-COPY nuget.config ./
-COPY ["Maliev.Service.Api/Maliev.Service.Api.csproj", "Maliev.Service.Api/"]
-RUN --mount=type=secret,id=nuget_username \
-    --mount=type=secret,id=nuget_password \
-    NUGET_USERNAME=$(cat /run/secrets/nuget_username) \
-    NUGET_PASSWORD=$(cat /run/secrets/nuget_password) \
-    dotnet restore "Maliev.Service.Api/Maliev.Service.Api.csproj"
-COPY . .
-WORKDIR "/Maliev.Service.Api"
-RUN dotnet publish -c Release -o /app/publish
-
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
-WORKDIR /app
-RUN chown -R app:app /app
-USER app
-COPY --from=build /app/publish .
-EXPOSE 8080
-ENV ASPNETCORE_URLS=http://+:8080
-HEALTHCHECK CMD curl -f http://localhost:8080/[service-name]/liveness || exit 1
-ENTRYPOINT ["dotnet", "Maliev.Service.Api.dll"]
-```
-
-**Rationale:** Microsoft's built-in `app` user provides security without complexity. BuildKit secrets prevent credential exposure in Docker image layers. Following Docker best practices ensures consistent, secure, and efficient container images across all services.
+### XI. GitHub Configuration
+*   **CODEOWNERS**: Mandatory at `.github/CODEOWNERS`.
+*   **Dependabot**: `dependabot.yml` is required in all services.
+*   **Workflows**: `.github/workflows` MUST include PR validation, Gemini workflows, and CI workflows for `dev`/`staging`/`main`.
 
 ---
 
-### XI. Simplicity & Maintainability
+## 🧪 5. Testing & Validation
 
-* Apply YAGNI
-* Favor readable, stateless design
-* Shared libraries must be versioned and documented
-
----
-
-### XII. Business Metrics & Analytics (NON-NEGOTIABLE)
-
-* Every service must expose **business-relevant metrics and analytics endpoints** for use by the company's telemetry pipeline.
-* Metrics must quantify both **system health** and **business outcomes**, including (where applicable):
-
-  * Number of processed jobs, quotes, or transactions
-  * Active users, conversion rates, and session durations
-  * Production throughput, revenue per feature, or machine utilization
-* Metrics must use **structured formats** compatible with Prometheus, OpenTelemetry, or other standard collectors.
-* Services must tag metrics with:
-
-  * `service_name`
-  * `version`
-  * `region`
-  * `environment` (dev/staging/prod)
-* Each release must define a clear mapping between **business objectives** and the metrics implemented.
-* Tests must validate the **presence and format** of required metrics endpoints.
-* Metrics must not expose confidential or personally identifiable information.
-
-**Rationale:** Analytics convert operational data into measurable business intelligence. This enables data-driven decisions for product strategy, cost optimization, and growth.
+### XII. Testing Mandates
+*   **Code Coverage**: Minimum **80% coverage** required for all services.
+*   **Real Infrastructure**: Use **Testcontainers** for all integration tests. In-memory databases are prohibited.
 
 ---
 
-### XIII. .NET Aspire Integration (NON-NEGOTIABLE)
+## 📦 6. Containerization & Deployment
 
-* **ServiceDefaults as NuGet Package**: All microservices MUST consume `Maliev.Aspire.ServiceDefaults` as a NuGet package from GitHub Packages, NOT as a project reference
-* **Package Source Configuration**: Each repository MUST have a `nuget.config` file pointing to GitHub Packages with credential placeholders
-* **CI/CD Authentication**: Workflows MUST use `GITOPS_PAT` (with `read:packages` scope) for NuGet authentication - `GITHUB_TOKEN` is insufficient for cross-repo packages
-* **Docker BuildKit Secrets**: Dockerfiles MUST use BuildKit secrets (`--mount=type=secret`) for NuGet credentials - using `ARG` for credentials is FORBIDDEN (exposes in image layers)
-* **Program.cs Integration**: All services MUST call `builder.AddServiceDefaults()` and `app.MapDefaultEndpoints()`
-* **nuget.config Mandatory**: Repository root MUST contain `nuget.config` with GitHub Packages source and `%NUGET_USERNAME%`/`%NUGET_PASSWORD%` placeholders
+### XIII. Docker Standards
+*   **Location**: `Dockerfile` MUST be located in the API project folder.
+*   **Structure**: Use optimized, multi-stage builds.
+*   **Best Practices**: Use the built-in `app` user; ensure correct file ownership.
 
-**Rationale:** Each microservice has its own Git repository. Project references (`../../Maliev.Aspire/...`) fail in CI because the Aspire repository is not present in the microservice's checkout context. Using a NuGet package from GitHub Packages enables independent CI/CD pipelines while maintaining shared observability standards. BuildKit secrets prevent credential exposure in Docker image layers.
-
----
-
-### XIV. Code Quality & Library Standards (NON-NEGOTIABLE)
-
-* **NO AutoMapper**: Explicit mapping only.
-  * **Rationale**: AutoMapper hides references, makes refactoring difficult, and introduces runtime errors that should be compile-time errors. Explicit mapping is explicit, searchable, and performant.
-* **NO FluentValidation**: Use standard .NET DataAnnotations or manual validation logic.
-  * **Rationale**: FluentValidation adds unnecessary complexity and abstraction. Standard validation is built-in, sufficient, and reduces dependency bloat.
-* **NO FluentAssertions**: Use standard xUnit `Assert`.
-  * **Rationale**: FluentAssertions adds a large dependency and encourages readable but sometimes ambiguous assertions. Standard `Assert` is part of the test framework, faster, and sufficient.
+### XIV. GitOps & GKE
+*   **Deployments**: Managed via `maliev-gitops` using **ArgoCD**.
+*   **Infrastructure**: Standardized resource definitions for Redis, RabbitMQ, and Postgres across environments.
 
 ---
 
-### XV. Project Structure & Naming (NON-NEGOTIABLE)
-
-* **Flat Structure**: For .NET applications, create the API, Data, and Tests projects **directly at the root of the repository**.
-  * ❌ NO `/src` folder
-  * ❌ NO `/tests` folder
-* **Naming Convention**: Projects MUST be named with the full company prefix.
-  * ✅ `Maliev.UploadService.Api`
-  * ❌ `UploadService.Api`
-* **Dockerfile Placement**: Must be inside the API project folder, NOT at the root.
-
----
-
-### XVI. CI/CD Standards (NON-NEGOTIABLE)
-
-* **Workflow Filenames**: GitHub Actions workflows MUST be named explicitly:
-  * `ci-develop.yml`
-  * `ci-staging.yml`
-  * `ci-main.yml`
-* **No Docker Compose**: Use **Testcontainers** for all integration tests and local development verification. `docker-compose.yml` is NOT required or recommended.
-
----
-
-## Deployment & Operations Standards
-
-* All services containerized via Docker
-* Configurable solely by environment variables
-* Rate limiting and recovery mechanisms mandatory
-* Services must emit metrics consumable by the central telemetry gateway
-* Metrics availability verified during deployment pipeline
-
----
-
-## Development Workflow
-
-**Mandatory sequence:**
-
-1. Specification
-2. **Test Definition (includes metrics tests)**
-3. Implementation
-4. Validation (tests, coverage, analytics endpoints)
-5. Refactor
-
-* Pull requests without analytics instrumentation will be rejected.
-* CI/CD must verify both functional tests and metrics schema compliance.
-
----
-
-## Security Compliance & Audit Requirements
-
-* Pre-commit scans for secrets and sensitive endpoints
-* Compromised credentials rotated within 24 hours
-* Quarterly audits of metrics exposure to ensure no PII leakage
-
----
-
-## Governance
-
-* Constitution supersedes developer preference.
-* All PRs validated for constitutional and analytics compliance.
-* Amendments require leadership approval and documented migration plan.
-* Violations block merge or deployment.
-
----
-
-**Version:** 1.7.0 | **Ratified:** 2025-12-04 | **Last Amended:** 2025-12-04
+**Version:** 2.0.0 | **Ratified:** 2026-02-22 | **Last Amended:** 2026-02-22

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,14 +1,14 @@
 <Project>
   <ItemGroup>
-    <PackageReference Update="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="10.0.2" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.2" />
-    <PackageReference Update="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.2" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-    <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
-    <PackageReference Update="Microsoft.Extensions.Options" Version="10.0.2" />
+    <PackageReference Update="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.3" />
+    <PackageReference Update="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.3" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Update="Microsoft.Extensions.Options" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/Maliev.AuthService.Api/Services/AccountLockoutService.cs
+++ b/Maliev.AuthService.Api/Services/AccountLockoutService.cs
@@ -1,6 +1,7 @@
 using Maliev.AuthService.Data.DbContexts;
 using Maliev.AuthService.Data.Entities;
 using Maliev.MessagingContracts.Generated;
+using Maliev.MessagingContracts.Contracts.Auth;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 

--- a/Maliev.AuthService.Api/Services/AuthenticationService.cs
+++ b/Maliev.AuthService.Api/Services/AuthenticationService.cs
@@ -792,15 +792,14 @@ public class AuthenticationService : IAuthenticationService
                 return (false, null, null, null, null, "service_unavailable");
             }
 
-            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
-            var result = await response.Content.ReadFromJsonAsync<EmployeeLookupResult>(jsonOptions);
+            var result = await response.Content.ReadFromJsonAsync<EmployeeLookupResult>();
             if (result == null)
             {
                 _logger.LogWarning("Employee lookup returned null result for email: {Email}", email);
                 return (false, null, null, null, null, "service_unavailable");
             }
 
-            return (true, result.EmployeeId, result.PrincipalId, result.FullName, result.EmploymentStatus, null);
+            return (true, result.Id, result.PrincipalId, result.FullName, result.EmploymentStatus, null);
         }
         catch (OperationCanceledException)
         {
@@ -834,14 +833,13 @@ public class AuthenticationService : IAuthenticationService
                 return (false, null, null, null, null, "provision_failed");
             }
 
-            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
-            var result = await response.Content.ReadFromJsonAsync<EmployeeLookupResult>(jsonOptions);
+            var result = await response.Content.ReadFromJsonAsync<ProvisionEmployeeResult>();
             if (result == null)
             {
                 return (false, null, null, null, null, "service_unavailable");
             }
 
-            return (true, result.EmployeeId, result.PrincipalId, result.FullName, result.EmploymentStatus, null);
+            return (true, result.Id, result.PrincipalId, null, null, null);
         }
         catch (Exception ex)
         {
@@ -889,8 +887,7 @@ public class AuthenticationService : IAuthenticationService
                 return (false, null, null, null, null, "Invalid credentials");
             }
 
-            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
-            var result = await response.Content.ReadFromJsonAsync<CredentialValidationResult>(jsonOptions);
+            var result = await response.Content.ReadFromJsonAsync<CredentialValidationResult>();
             if (result == null || !result.IsValid)
             {
 
@@ -949,10 +946,18 @@ public class AuthenticationService : IAuthenticationService
 
     private record EmployeeLookupResult
     {
-        public Guid EmployeeId { get; init; }
+        public Guid Id { get; init; }
         public Guid PrincipalId { get; init; }
         public string Email { get; init; } = string.Empty;
-        public string FullName { get; init; } = string.Empty;
+        public string FirstName { get; init; } = string.Empty;
+        public string LastName { get; init; } = string.Empty;
+        public string FullName => $"{FirstName} {LastName}".Trim();
         public string EmploymentStatus { get; init; } = string.Empty;
+    }
+
+    private record ProvisionEmployeeResult
+    {
+        public Guid Id { get; init; }
+        public Guid PrincipalId { get; init; }
     }
 }

--- a/Maliev.AuthService.Api/Services/AuthenticationService.cs
+++ b/Maliev.AuthService.Api/Services/AuthenticationService.cs
@@ -3,6 +3,7 @@ using Maliev.AuthService.Api.Models.Response;
 using Maliev.AuthService.Data.DbContexts;
 using Maliev.AuthService.Data.Entities;
 using Maliev.Aspire.ServiceDefaults.IAM;
+using Maliev.MessagingContracts.Contracts.Auth;
 using Microsoft.EntityFrameworkCore;
 using System.Net;
 using System.Security.Cryptography;
@@ -82,7 +83,7 @@ public class AuthenticationService : IAuthenticationService
         {
             await LogAuditAsync(null, userType, "login", ipAddress, false, "Rate limit exceeded");
 
-            await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.LoginFailedEvent(
+            await _publishEndpoint.Publish(new LoginFailedEvent(
                 Guid.NewGuid(),
                 "LoginFailedEvent",
                 Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -93,7 +94,7 @@ public class AuthenticationService : IAuthenticationService
                 null,
                 DateTimeOffset.UtcNow,
                 false,
-                new Maliev.MessagingContracts.Generated.LoginFailedEventPayload(
+                new LoginFailedEventPayload(
                     request.Username,
                     null,
                     normalizedType == "customer" ? "Customer" : "Employee",
@@ -121,7 +122,7 @@ public class AuthenticationService : IAuthenticationService
         {
             await LogAuditAsync(validationResult.UserId.Value, userType, "login", ipAddress, false, "Account locked");
 
-            await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.LoginFailedEvent(
+            await _publishEndpoint.Publish(new LoginFailedEvent(
                 Guid.NewGuid(),
                 "LoginFailedEvent",
                 Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -132,7 +133,7 @@ public class AuthenticationService : IAuthenticationService
                 null,
                 DateTimeOffset.UtcNow,
                 false,
-                new Maliev.MessagingContracts.Generated.LoginFailedEventPayload(
+                new LoginFailedEventPayload(
                     request.Username,
                     validationResult.UserId.Value.ToString(),
                     normalizedType == "customer" ? "Customer" : "Employee",
@@ -168,7 +169,7 @@ public class AuthenticationService : IAuthenticationService
 
             await LogAuditAsync(validationResult.UserId, userType, "login", ipAddress, false, validationResult.FailureReason);
 
-            await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.LoginFailedEvent(
+            await _publishEndpoint.Publish(new LoginFailedEvent(
                 Guid.NewGuid(),
                 "LoginFailedEvent",
                 Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -179,7 +180,7 @@ public class AuthenticationService : IAuthenticationService
                 null,
                 DateTimeOffset.UtcNow,
                 false,
-                new Maliev.MessagingContracts.Generated.LoginFailedEventPayload(
+                new LoginFailedEventPayload(
                     request.Username,
                     validationResult.UserId?.ToString(),
                     normalizedType == "customer" ? "Customer" : "Employee",
@@ -238,7 +239,7 @@ public class AuthenticationService : IAuthenticationService
 
         await LogAuditAsync(userId, userType, "login", ipAddress, true, null);
 
-        await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.UserLoggedInEvent(
+        await _publishEndpoint.Publish(new UserLoggedInEvent(
             Guid.NewGuid(),
             "UserLoggedInEvent",
             Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -249,7 +250,7 @@ public class AuthenticationService : IAuthenticationService
             null,
             DateTimeOffset.UtcNow,
             false,
-            new Maliev.MessagingContracts.Generated.UserLoggedInEventPayload(
+            new UserLoggedInEventPayload(
                 userId.ToString(),
                 principalId.ToString(),
                 normalizedType == "customer" ? "Customer" : "Employee",
@@ -438,7 +439,7 @@ public class AuthenticationService : IAuthenticationService
 
         await LogAuditAsync(refreshToken.UserId, refreshToken.UserType, "logout", null, true, null);
 
-        await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.UserLoggedOutEvent(
+        await _publishEndpoint.Publish(new UserLoggedOutEvent(
             Guid.NewGuid(),
             "UserLoggedOutEvent",
             Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -449,7 +450,7 @@ public class AuthenticationService : IAuthenticationService
             null,
             DateTimeOffset.UtcNow,
             false,
-            new Maliev.MessagingContracts.Generated.UserLoggedOutEventPayload(
+            new UserLoggedOutEventPayload(
                 refreshToken.UserId.ToString(),
                 refreshToken.UserType == UserType.Customer ? "Customer" : "Employee",
                 DateTimeOffset.UtcNow
@@ -469,7 +470,7 @@ public class AuthenticationService : IAuthenticationService
         {
             await LogAuditAsync(null, null, "service_login", ipAddress, false, "Invalid client ID");
 
-            await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.LoginFailedEvent(
+            await _publishEndpoint.Publish(new LoginFailedEvent(
                 Guid.NewGuid(),
                 "LoginFailedEvent",
                 Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -480,7 +481,7 @@ public class AuthenticationService : IAuthenticationService
                 null,
                 DateTimeOffset.UtcNow,
                 false,
-                new Maliev.MessagingContracts.Generated.LoginFailedEventPayload(
+                new LoginFailedEventPayload(
                     request.ClientId,
                     null,
                     "Service",
@@ -500,7 +501,7 @@ public class AuthenticationService : IAuthenticationService
         {
             await LogAuditAsync(null, null, "service_login", ipAddress, false, "Invalid client secret");
 
-            await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.LoginFailedEvent(
+            await _publishEndpoint.Publish(new LoginFailedEvent(
                 Guid.NewGuid(),
                 "LoginFailedEvent",
                 Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -511,7 +512,7 @@ public class AuthenticationService : IAuthenticationService
                 null,
                 DateTimeOffset.UtcNow,
                 false,
-                new Maliev.MessagingContracts.Generated.LoginFailedEventPayload(
+                new LoginFailedEventPayload(
                     request.ClientId,
                     null,
                     "Service",
@@ -557,7 +558,7 @@ public class AuthenticationService : IAuthenticationService
 
         await LogAuditAsync(null, null, "service_login", ipAddress, true, null);
 
-        await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.UserLoggedInEvent(
+        await _publishEndpoint.Publish(new UserLoggedInEvent(
             Guid.NewGuid(),
             "UserLoggedInEvent",
             Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -568,7 +569,7 @@ public class AuthenticationService : IAuthenticationService
             null,
             DateTimeOffset.UtcNow,
             false,
-            new Maliev.MessagingContracts.Generated.UserLoggedInEventPayload(
+            new UserLoggedInEventPayload(
                 request.ClientId,
                 serviceCredential.PrincipalId?.ToString(),
                 "Service",
@@ -724,7 +725,7 @@ public class AuthenticationService : IAuthenticationService
         // 7. Audit log + publish UserLoggedInEvent
         await LogAuditAsync(employeeId.Value, UserType.Employee, "google_exchange", ipAddress, true, null);
 
-        await _publishEndpoint.Publish(new Maliev.MessagingContracts.Generated.UserLoggedInEvent(
+        await _publishEndpoint.Publish(new UserLoggedInEvent(
             Guid.NewGuid(),
             "UserLoggedInEvent",
             Maliev.MessagingContracts.Generated.MessageType.Event,
@@ -735,7 +736,7 @@ public class AuthenticationService : IAuthenticationService
             null,
             DateTimeOffset.UtcNow,
             false,
-            new Maliev.MessagingContracts.Generated.UserLoggedInEventPayload(
+            new UserLoggedInEventPayload(
                 employeeId.Value.ToString(),
                 principalId.Value.ToString(),
                 "Employee",

--- a/Maliev.AuthService.Api/Services/RefreshTokenService.cs
+++ b/Maliev.AuthService.Api/Services/RefreshTokenService.cs
@@ -1,6 +1,7 @@
 using Maliev.AuthService.Data.DbContexts;
 using Maliev.AuthService.Data.Entities;
 using Maliev.MessagingContracts.Generated;
+using Maliev.MessagingContracts.Contracts.Auth;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -13,9 +13,6 @@ namespace Maliev.AuthService.Tests.Contract;
 
 public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, AuthDbContext>
 {
-    /// <summary>
-    /// Override CleanDatabaseAsync to seed required test data after cleanup and clear Redis
-    /// </summary>
     public new async Task CleanDatabaseAsync()
     {
         await base.CleanDatabaseAsync();
@@ -23,15 +20,11 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         await SeedTestDataAsync();
     }
 
-    /// <summary>
-    /// Clears all Redis keys to ensure clean state between tests
-    /// </summary>
     private async Task ClearRedisAsync()
     {
         var redisConnectionString = Environment.GetEnvironmentVariable("ConnectionStrings__redis");
         if (!string.IsNullOrEmpty(redisConnectionString))
         {
-            // Add allowAdmin=true to enable FLUSHALL command
             var connectionString = $"{redisConnectionString},allowAdmin=true";
             await using var connection = await StackExchange.Redis.ConnectionMultiplexer.ConnectAsync(connectionString);
             var server = connection.GetServer(connection.GetEndPoints().First());
@@ -39,19 +32,15 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         }
     }
 
-    /// <summary>
-    /// Seeds required test data for AuthService tests
-    /// </summary>
     private async Task SeedTestDataAsync()
     {
         await using var context = GetDbContext();
 
-        // Seed service credentials for service login tests
         var serviceCredential = new Maliev.AuthService.Data.Entities.ServiceCredential
         {
             Id = Guid.NewGuid(),
             ClientId = "service-dev-customer-api",
-            PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"), // Test principal ID for IAM integration
+            PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
             ClientSecretHash = ComputeSha256Hash(TestConstants.DummyValidServiceSecret),
             ServiceName = "Customer API Service",
             IsActive = true,
@@ -63,9 +52,6 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         await context.SaveChangesAsync();
     }
 
-    /// <summary>
-    /// Computes SHA-256 hash of a string
-    /// </summary>
     private static string ComputeSha256Hash(string input)
     {
         using var sha256 = System.Security.Cryptography.SHA256.Create();
@@ -76,26 +62,19 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
 
     protected override void ConfigureEnvironmentVariables()
     {
-        // Set IAM registration delay to 0 for immediate registration in tests
         Environment.SetEnvironmentVariable("IAM__RegistrationDelaySeconds", "0");
-
-        // Set external service URLs via environment variables for testing
         Environment.SetEnvironmentVariable("CustomerService__BaseUrl", "http://localhost:5001");
         Environment.SetEnvironmentVariable("EmployeeService__BaseUrl", "http://localhost:5002");
         Environment.SetEnvironmentVariable("IAMService__BaseUrl", "http://localhost:5100");
 
-        // Export RSA private and public keys for JWT token generation and validation
-        // The base factory provides _testRsa through SigningCredentials property
         var rsa = (SigningCredentials.Key as RsaSecurityKey)?.Rsa;
         if (rsa != null)
         {
-            // Export private key for token generation (PKCS#8 format for ImportPkcs8PrivateKey)
             var privateKeyPem = rsa.ExportPkcs8PrivateKeyPem();
             var privateKeyBase64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(privateKeyPem));
             Environment.SetEnvironmentVariable("Jwt__PrivateKey", privateKeyBase64);
 
-            // Export public key for token validation
-            var publicKeyPem = rsa.ExportSubjectPublicKeyInfoPem();  // Use SubjectPublicKeyInfo format
+            var publicKeyPem = rsa.ExportSubjectPublicKeyInfoPem();
             var publicKeyBase64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(publicKeyPem));
             Environment.SetEnvironmentVariable("Jwt__PublicKey", publicKeyBase64);
         }
@@ -103,14 +82,12 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
 
     protected override void ConfigureAdditionalServices(IServiceCollection services)
     {
-        // Remove existing HttpClient registration
         var httpClientDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IHttpClientFactory));
         if (httpClientDescriptor != null)
         {
             services.Remove(httpClientDescriptor);
         }
 
-        // Add mock HTTP client factory that returns successful validation responses
         services.AddSingleton<IHttpClientFactory>(sp => new MockHttpClientFactory(sp.GetRequiredService<IConfiguration>()));
     }
 
@@ -128,7 +105,6 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
             var handler = new MockHttpMessageHandler();
             var client = new HttpClient(handler);
 
-            // Try to get BaseAddress from configuration, default to localhost if not found
             var iamBaseUrl = _configuration["IAMService:BaseUrl"];
             if (!string.IsNullOrEmpty(iamBaseUrl))
             {
@@ -147,7 +123,6 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
     {
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            // Mock external service validation responses
             if (request.RequestUri?.PathAndQuery.Contains("/validate") == true)
             {
                 string? username = null;
@@ -174,9 +149,9 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                 {
                     var response = new
                     {
-                        is_valid = true,
-                        user_id = Guid.NewGuid(),
-                        principal_id = Guid.NewGuid(),
+                        isValid = true,
+                        userId = Guid.NewGuid(),
+                        principalId = Guid.NewGuid(),
                         email = username,
                         name = "Test User"
                     };
@@ -204,8 +179,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
 
                 var invalidResponse = new
                 {
-                    is_valid = false,
-                    user_id = generatedUserId,
+                    isValid = false,
+                    userId = generatedUserId,
                     error = "Invalid credentials"
                 };
 
@@ -216,7 +191,6 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                 };
             }
 
-            // Mock IAM resolution response
             if (request.RequestUri?.PathAndQuery.Contains("/iam/v1/auth/resolve-permissions") == true)
             {
                 if (request.RequestUri.Port == 5101)
@@ -247,7 +221,6 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                 };
             }
 
-            // Mock EmployeeService by-email endpoint
             if (request.RequestUri?.PathAndQuery.Contains("/employee/v1/employees/by-email/") == true)
             {
                 var email = Uri.UnescapeDataString(request.RequestUri.Segments.Last());
@@ -261,11 +234,11 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                 {
                     var response = new
                     {
-                        employee_id = Guid.NewGuid(),
-                        principal_id = Guid.Parse("7c9e6639-7420-4007-8596-f0ad96130444"),
+                        id = Guid.NewGuid(),
+                        principalId = Guid.Parse("7c9e6639-7420-4007-8596-f0ad96130444"),
                         email = email,
-                        full_name = "Existing Employee",
-                        employment_status = "Active"
+                        fullName = "Existing Employee",
+                        employmentStatus = "Active"
                     };
 
                     return new HttpResponseMessage(HttpStatusCode.OK)
@@ -278,11 +251,11 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                 {
                     var response = new
                     {
-                        employee_id = Guid.NewGuid(),
-                        principal_id = Guid.NewGuid(),
+                        id = Guid.NewGuid(),
+                        principalId = Guid.NewGuid(),
                         email = email,
-                        full_name = "Terminated Employee",
-                        employment_status = "Terminated"
+                        fullName = "Terminated Employee",
+                        employmentStatus = "Terminated"
                     };
 
                     return new HttpResponseMessage(HttpStatusCode.OK)
@@ -294,11 +267,11 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                 return new HttpResponseMessage(HttpStatusCode.NotFound);
             }
 
-            // Mock EmployeeService auto-provision endpoint
             if (request.RequestUri?.PathAndQuery.Contains("/employee/v1/employees/auto-provision") == true)
             {
                 string? email = null;
-                string? fullName = null;
+                string? firstName = null;
+                string? lastName = null;
 
                 if (request.Content != null)
                 {
@@ -306,8 +279,10 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                     var jsonDoc = JsonDocument.Parse(requestBody);
                     if (jsonDoc.RootElement.TryGetProperty("email", out var emailElement))
                         email = emailElement.GetString();
-                    if (jsonDoc.RootElement.TryGetProperty("full_name", out var fullNameElement))
-                        fullName = fullNameElement.GetString();
+                    if (jsonDoc.RootElement.TryGetProperty("first_name", out var firstNameElement))
+                        firstName = firstNameElement.GetString();
+                    if (jsonDoc.RootElement.TryGetProperty("last_name", out var lastNameElement))
+                        lastName = lastNameElement.GetString();
                 }
 
                 if (email == "provision.fail@maliev.com")
@@ -317,12 +292,12 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
 
                 var response = new
                 {
-                    employee_id = Guid.NewGuid(),
-                    principal_id = Guid.NewGuid(),
+                    id = Guid.NewGuid(),
+                    principalId = Guid.NewGuid(),
                     email = email,
-                    full_name = fullName ?? "New Employee",
-                    employee_number = "EMP-TEST-001",
-                    employment_status = "Active"
+                    firstName = firstName ?? "New",
+                    lastName = lastName ?? "Employee",
+                    employmentStatus = "Active"
                 };
 
                 return new HttpResponseMessage(HttpStatusCode.OK)

--- a/Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj
+++ b/Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj
+++ b/Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />

--- a/Maliev.AuthService.Tests/Unit/AccountLockoutServiceTests.cs
+++ b/Maliev.AuthService.Tests/Unit/AccountLockoutServiceTests.cs
@@ -2,6 +2,7 @@ using Maliev.AuthService.Api.Services;
 using Maliev.AuthService.Data.DbContexts;
 using Maliev.AuthService.Data.Entities;
 using Maliev.AuthService.Tests.Infrastructure;
+using Maliev.MessagingContracts.Contracts.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -106,7 +107,7 @@ public class AccountLockoutServiceTests : IClassFixture<TestDatabaseFixture>, IA
         var lockout = await dbContext.AccountLockouts.FirstAsync(l => l.UserId == userId);
         Assert.Equal(5, lockout.FailedAttempts);
         Assert.NotNull(lockout.LockedUntil);
-        _publishEndpointMock.Verify(p => p.Publish(It.IsAny<Maliev.MessagingContracts.Generated.UserAccountLockedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+        _publishEndpointMock.Verify(p => p.Publish(It.IsAny<UserAccountLockedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/Maliev.AuthService.Tests/Unit/AuthenticationServiceTests.cs
+++ b/Maliev.AuthService.Tests/Unit/AuthenticationServiceTests.cs
@@ -131,11 +131,11 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
         {
             Content = JsonContent.Create(new
             {
-                employee_id = employeeId,
-                principal_id = principalId,
+                id = employeeId,
+                principalId = principalId,
                 email = email,
-                full_name = "New User",
-                employment_status = "Active"
+                fullName = "New User",
+                employmentStatus = "Active"
             })
         };
         _employeeServiceClientMock.Setup(s => s.ProvisionEmployeeAsync(It.IsAny<object>()))
@@ -211,11 +211,11 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
         {
             Content = JsonContent.Create(new
             {
-                employee_id = employeeId,
-                principal_id = Guid.NewGuid(),
+                id = employeeId,
+                principalId = Guid.NewGuid(),
                 email = email,
-                full_name = "User",
-                employment_status = "Terminated"
+                fullName = "User",
+                employmentStatus = "Terminated"
             })
         };
         _employeeServiceClientMock.Setup(s => s.GetEmployeeByEmailAsync(email))

--- a/Maliev.AuthService.Tests/Unit/RefreshTokenServiceTests.cs
+++ b/Maliev.AuthService.Tests/Unit/RefreshTokenServiceTests.cs
@@ -2,6 +2,7 @@ using Maliev.AuthService.Api.Services;
 using Maliev.AuthService.Data.DbContexts;
 using Maliev.AuthService.Data.Entities;
 using Maliev.AuthService.Tests.Infrastructure;
+using Maliev.MessagingContracts.Contracts.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -137,7 +138,7 @@ public class RefreshTokenServiceTests : IClassFixture<TestDatabaseFixture>, IAsy
             var otherToken = await dbContext.RefreshTokens.FirstOrDefaultAsync(rt => rt.TokenHash == "other-token");
             Assert.True(otherToken!.IsUsed); // Should be revoked
         }
-        _publishEndpointMock.Verify(p => p.Publish(It.IsAny<Maliev.MessagingContracts.Generated.SuspiciousActivityDetectedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+        _publishEndpointMock.Verify(p => p.Publish(It.IsAny<SuspiciousActivityDetectedEvent>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Updates EmployeeLookupResult record to use Id instead of EmployeeId to match updated EmployeeService response
- Splits FullName into FirstName/LastName fields matching the new EmployeeService DTO
- Adds ProvisionEmployeeResult record for auto-provisioning response (separate from lookup)
- Removes custom JsonNamingPolicy (uses default camelCase deserialization)
- Bumps Microsoft.EntityFrameworkCore and Microsoft.EntityFrameworkCore.Sqlite to 10.0.3 in Tests project to resolve package downgrade conflict with Npgsql.EntityFrameworkCore.PostgreSQL 10.0.0

## Test plan
- [ ] Verify authentication flow with employee lookup
- [ ] Test auto-provisioning of new employees
- [ ] Verify credential validation flow