### PR TITLE
Secure passkey assertion verification and containment

### DIFF
--- a/Maliev.AuthService.Api/Controllers/AuthenticationController.cs
+++ b/Maliev.AuthService.Api/Controllers/AuthenticationController.cs
@@ -20,7 +20,6 @@ public class AuthenticationController : ControllerBase
 {
     private readonly IAuthenticationService _authenticationService;
     private readonly IEmailVerificationService _emailVerificationService;
-    private readonly IPasskeyService _passkeyService;
     private readonly IGoogleIdentityNonceService _googleIdentityNonceService;
     private readonly IConfiguration _configuration;
     private readonly ILogger<AuthenticationController> _logger;
@@ -30,21 +29,18 @@ public class AuthenticationController : ControllerBase
     /// </summary>
     /// <param name="authenticationService">The service responsible for authentication logic.</param>
     /// <param name="emailVerificationService">The service responsible for email verification.</param>
-    /// <param name="passkeyService">The service responsible for WebAuthn passkey operations.</param>
     /// <param name="googleIdentityNonceService">The one-time Google identity nonce service.</param>
     /// <param name="configuration">The application configuration.</param>
     /// <param name="logger">The logger for this controller.</param>
     public AuthenticationController(
         IAuthenticationService authenticationService,
         IEmailVerificationService emailVerificationService,
-        IPasskeyService passkeyService,
         IGoogleIdentityNonceService googleIdentityNonceService,
         IConfiguration configuration,
         ILogger<AuthenticationController> logger)
     {
         _authenticationService = authenticationService;
         _emailVerificationService = emailVerificationService;
-        _passkeyService = passkeyService;
         _googleIdentityNonceService = googleIdentityNonceService;
         _configuration = configuration;
         _logger = logger;
@@ -690,55 +686,39 @@ public class AuthenticationController : ControllerBase
     }
 
     /// <summary>
-    /// Begins WebAuthn passkey authentication by generating a challenge and credential request options.
+    /// Reports that the legacy v1 passkey authentication flow is unavailable.
     /// </summary>
     /// <remarks>
-    /// Returns credential request options needed by the client to invoke navigator.credentials.get().
-    /// If a principal ID is provided, the allowed credentials are scoped to that principal.
+    /// The original v1 contract accepted caller-authored identity context and cannot be safely upgraded
+    /// in place. Trusted BFF callers must migrate to the additive v2 ceremony endpoints.
     /// </remarks>
-    /// <param name="request">The authentication begin request.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>WebAuthn credential request options.</returns>
-    /// <response code="200">Authentication challenge created successfully.</response>
+    /// <returns>A stable service-unavailable response.</returns>
+    /// <response code="503">Legacy passkey authentication is unavailable.</response>
     [HttpPost("passkey/auth/begin")]
     [RequirePermission(AuthPermissions.ExchangeIdentities)]
-    [ProducesResponseType(typeof(PasskeyAuthBeginResponse), StatusCodes.Status200OK)]
-    public async Task<IActionResult> BeginPasskeyAuthentication([FromBody] PasskeyAuthBeginRequest request, CancellationToken cancellationToken)
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public IActionResult BeginPasskeyAuthentication(CancellationToken cancellationToken)
     {
-        var result = await _passkeyService.BeginAuthenticationAsync(request.PrincipalId, cancellationToken);
-        return Ok(result);
+        return PasskeyAuthenticationUnavailable();
     }
 
     /// <summary>
-    /// Completes WebAuthn passkey authentication by verifying the assertion signature.
+    /// Reports that the legacy v1 passkey authentication completion flow is unavailable.
     /// </summary>
     /// <remarks>
-    /// Validates the authenticator signature against the stored public key.
-    /// Updates the sign count and last used timestamp on successful verification.
+    /// The additive v2 contract binds the assertion to a service caller, application audience,
+    /// exact relying-party origin, and one-time server-owned ceremony.
     /// </remarks>
-    /// <param name="request">The authentication completion request with assertion response.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>Authentication result with principal information.</returns>
-    /// <response code="200">Authentication successful.</response>
-    /// <response code="401">Invalid credential or signature.</response>
+    /// <returns>A stable service-unavailable response.</returns>
+    /// <response code="503">Legacy passkey authentication is unavailable.</response>
     [HttpPost("passkey/auth/complete")]
     [RequirePermission(AuthPermissions.ExchangeIdentities)]
-    [ProducesResponseType(typeof(PasskeyAuthCompleteResponse), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> CompletePasskeyAuthentication([FromBody] PasskeyAuthCompleteRequest request, CancellationToken cancellationToken)
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public IActionResult CompletePasskeyAuthentication(CancellationToken cancellationToken)
     {
-        var result = await _passkeyService.CompleteAuthenticationAsync(request, cancellationToken);
-
-        if (!result.Success)
-        {
-            return Unauthorized(new ErrorResponse
-            {
-                Error = "authentication_failed",
-                ErrorDescription = result.Error ?? "Invalid credentials"
-            });
-        }
-
-        return Ok(result);
+        return PasskeyAuthenticationUnavailable();
     }
 
     /// <summary>
@@ -778,6 +758,18 @@ public class AuthenticationController : ControllerBase
         {
             Error = "passkey_registration_unavailable",
             ErrorDescription = "Passkey registration and credential management are temporarily unavailable"
+        })
+        {
+            StatusCode = StatusCodes.Status503ServiceUnavailable
+        };
+    }
+
+    private static ObjectResult PasskeyAuthenticationUnavailable()
+    {
+        return new ObjectResult(new ErrorResponse
+        {
+            Error = "passkey_authentication_unavailable",
+            ErrorDescription = "The legacy passkey authentication contract is unavailable; use the v2 ceremony flow"
         })
         {
             StatusCode = StatusCodes.Status503ServiceUnavailable

--- a/Maliev.AuthService.Api/Controllers/AuthenticationController.cs
+++ b/Maliev.AuthService.Api/Controllers/AuthenticationController.cs
@@ -652,53 +652,41 @@ public class AuthenticationController : ControllerBase
     }
 
     /// <summary>
-    /// Begins WebAuthn passkey registration by generating a challenge and creation options.
+    /// Reports that passkey registration is unavailable until complete WebAuthn verification is enabled.
     /// </summary>
     /// <remarks>
-    /// Returns credential creation options needed by the client to invoke navigator.credentials.create().
-    /// The challenge is stored server-side and expires after 5 minutes.
+    /// Registration is temporarily disabled because the current implementation does not provide the
+    /// complete WebAuthn attestation and ownership verification required for safe credential enrollment.
     /// </remarks>
     /// <param name="request">The registration begin request containing the principal ID.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>WebAuthn credential creation options.</returns>
-    /// <response code="200">Registration challenge created successfully.</response>
+    /// <returns>A stable service-unavailable response.</returns>
+    /// <response code="503">Passkey registration is unavailable.</response>
     [HttpPost("passkey/register/begin")]
-    [ProducesResponseType(typeof(PasskeyRegistrationBeginResponse), StatusCodes.Status200OK)]
-    public async Task<IActionResult> BeginPasskeyRegistration([FromBody] PasskeyRegistrationBeginRequest request, CancellationToken cancellationToken)
+    [RequirePermission(AuthPermissions.ExchangeIdentities)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public Task<IActionResult> BeginPasskeyRegistration([FromBody] PasskeyRegistrationBeginRequest request, CancellationToken cancellationToken)
     {
-        var result = await _passkeyService.BeginRegistrationAsync(request.PrincipalId, cancellationToken);
-        return Ok(result);
+        return Task.FromResult<IActionResult>(PasskeyRegistrationUnavailable());
     }
 
     /// <summary>
-    /// Completes WebAuthn passkey registration by verifying and storing the credential.
+    /// Reports that passkey registration is unavailable until complete WebAuthn verification is enabled.
     /// </summary>
     /// <remarks>
-    /// Verifies the challenge, enforces max passkeys per principal, and stores the credential.
-    /// Publishes a PasskeyRegisteredEvent upon success.
+    /// Registration is temporarily disabled because the current implementation does not provide the
+    /// complete WebAuthn attestation and ownership verification required for safe credential enrollment.
     /// </remarks>
     /// <param name="request">The registration completion request with authenticator response.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>Registration result.</returns>
-    /// <response code="200">Passkey registered successfully.</response>
-    /// <response code="400">Registration failed (challenge expired, duplicate credential, or max reached).</response>
+    /// <returns>A stable service-unavailable response.</returns>
+    /// <response code="503">Passkey registration is unavailable.</response>
     [HttpPost("passkey/register/complete")]
-    [ProducesResponseType(typeof(PasskeyRegistrationCompleteResponse), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CompletePasskeyRegistration([FromBody] PasskeyRegistrationCompleteRequest request, CancellationToken cancellationToken)
+    [RequirePermission(AuthPermissions.ExchangeIdentities)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public Task<IActionResult> CompletePasskeyRegistration([FromBody] PasskeyRegistrationCompleteRequest request, CancellationToken cancellationToken)
     {
-        var result = await _passkeyService.CompleteRegistrationAsync(request, cancellationToken);
-
-        if (!result.Success)
-        {
-            return BadRequest(new ErrorResponse
-            {
-                Error = "registration_failed",
-                ErrorDescription = result.Error ?? "Failed to complete passkey registration"
-            });
-        }
-
-        return Ok(result);
+        return Task.FromResult<IActionResult>(PasskeyRegistrationUnavailable());
     }
 
     /// <summary>
@@ -713,6 +701,7 @@ public class AuthenticationController : ControllerBase
     /// <returns>WebAuthn credential request options.</returns>
     /// <response code="200">Authentication challenge created successfully.</response>
     [HttpPost("passkey/auth/begin")]
+    [RequirePermission(AuthPermissions.ExchangeIdentities)]
     [ProducesResponseType(typeof(PasskeyAuthBeginResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> BeginPasskeyAuthentication([FromBody] PasskeyAuthBeginRequest request, CancellationToken cancellationToken)
     {
@@ -733,6 +722,7 @@ public class AuthenticationController : ControllerBase
     /// <response code="200">Authentication successful.</response>
     /// <response code="401">Invalid credential or signature.</response>
     [HttpPost("passkey/auth/complete")]
+    [RequirePermission(AuthPermissions.ExchangeIdentities)]
     [ProducesResponseType(typeof(PasskeyAuthCompleteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> CompletePasskeyAuthentication([FromBody] PasskeyAuthCompleteRequest request, CancellationToken cancellationToken)
@@ -752,45 +742,45 @@ public class AuthenticationController : ControllerBase
     }
 
     /// <summary>
-    /// Lists all passkey credentials for a principal.
+    /// Reports that passkey credential management is unavailable until complete WebAuthn verification is enabled.
     /// </summary>
     /// <param name="principalId">The principal identifier.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>List of passkey credentials.</returns>
-    /// <response code="200">Returns the list of credentials.</response>
+    /// <returns>A stable service-unavailable response.</returns>
+    /// <response code="503">Passkey credential management is unavailable.</response>
     [HttpGet("passkey/credentials")]
-    [ProducesResponseType(typeof(PasskeyListResponse), StatusCodes.Status200OK)]
-    public async Task<IActionResult> ListPasskeyCredentials([FromQuery] Guid principalId, CancellationToken cancellationToken)
+    [RequirePermission(AuthPermissions.ExchangeIdentities)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public Task<IActionResult> ListPasskeyCredentials([FromQuery] Guid principalId, CancellationToken cancellationToken)
     {
-        var result = await _passkeyService.ListCredentialsAsync(principalId, cancellationToken);
-        return Ok(result);
+        return Task.FromResult<IActionResult>(PasskeyRegistrationUnavailable());
     }
 
     /// <summary>
-    /// Deletes a passkey credential.
+    /// Reports that passkey credential management is unavailable until complete WebAuthn verification is enabled.
     /// </summary>
     /// <param name="credentialId">The credential identifier.</param>
     /// <param name="principalId">The principal who owns the credential.</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>Deletion result.</returns>
-    /// <response code="204">Credential deleted successfully.</response>
-    /// <response code="404">Credential not found.</response>
+    /// <returns>A stable service-unavailable response.</returns>
+    /// <response code="503">Passkey credential management is unavailable.</response>
     [HttpDelete("passkey/credentials/{credentialId}")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeletePasskeyCredential(Guid credentialId, [FromQuery] Guid principalId, CancellationToken cancellationToken)
+    [RequirePermission(AuthPermissions.ExchangeIdentities)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public Task<IActionResult> DeletePasskeyCredential(Guid credentialId, [FromQuery] Guid principalId, CancellationToken cancellationToken)
     {
-        var result = await _passkeyService.DeleteCredentialAsync(credentialId, principalId, cancellationToken);
+        return Task.FromResult<IActionResult>(PasskeyRegistrationUnavailable());
+    }
 
-        if (!result)
+    private static ObjectResult PasskeyRegistrationUnavailable()
+    {
+        return new ObjectResult(new ErrorResponse
         {
-            return NotFound(new ErrorResponse
-            {
-                Error = "credential_not_found",
-                ErrorDescription = "Credential not found"
-            });
-        }
-
-        return NoContent();
+            Error = "passkey_registration_unavailable",
+            ErrorDescription = "Passkey registration and credential management are temporarily unavailable"
+        })
+        {
+            StatusCode = StatusCodes.Status503ServiceUnavailable
+        };
     }
 }

--- a/Maliev.AuthService.Api/Controllers/PasskeyAuthenticationController.cs
+++ b/Maliev.AuthService.Api/Controllers/PasskeyAuthenticationController.cs
@@ -1,0 +1,185 @@
+using Asp.Versioning;
+using Maliev.Aspire.ServiceDefaults.Authorization;
+using Maliev.AuthService.Api.Authorization;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Application.DTOs.Response;
+using Maliev.AuthService.Application.Interfaces;
+using Maliev.AuthService.Infrastructure.Security;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Maliev.AuthService.Api.Controllers;
+
+/// <summary>
+/// Handles caller-bound, server-verified WebAuthn authentication ceremonies.
+/// </summary>
+[ApiController]
+[ApiVersion("2")]
+[Route("auth/v{version:apiVersion}/passkey/auth")]
+public sealed class PasskeyAuthenticationController(
+    IPasskeyService passkeyService,
+    IOptions<PasskeyWebAuthnOptions> options,
+    ILogger<PasskeyAuthenticationController> logger) : ControllerBase
+{
+    private readonly PasskeyWebAuthnOptions _options = options.Value;
+
+    /// <summary>
+    /// Starts a discoverable-credential WebAuthn authentication ceremony.
+    /// </summary>
+    /// <param name="request">The server-owned application audience.</param>
+    /// <param name="cancellationToken">Token used to cancel the request.</param>
+    /// <returns>One-time browser assertion options.</returns>
+    /// <response code="200">The one-time assertion options were issued.</response>
+    /// <response code="400">The request attempted to supply identity context.</response>
+    /// <response code="403">The service caller is not bound to the application.</response>
+    /// <response code="503">Passkey authentication is unavailable.</response>
+    [HttpPost("begin")]
+    [RequirePermission(AuthPermissions.ExchangeIdentities)]
+    [ProducesResponseType(typeof(PasskeyAuthBeginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    [RequestSizeLimit(4 * 1024)]
+    public async Task<IActionResult> Begin(
+        [FromBody] PasskeyAuthBeginRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetBoundCaller(request.Application, out var serviceName, out var application))
+        {
+            return Forbid();
+        }
+
+        if (request.PrincipalId.HasValue)
+        {
+            return BadRequest(new ErrorResponse
+            {
+                Error = "passkey_flow_invalid",
+                ErrorDescription = "Passkey authentication must use a discoverable credential flow"
+            });
+        }
+
+        request.Application = application;
+        var result = await passkeyService.BeginAuthenticationAsync(
+            request,
+            serviceName,
+            cancellationToken);
+        if (result is null)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new ErrorResponse
+            {
+                Error = "passkey_temporarily_unavailable",
+                ErrorDescription = "Passkey authentication is temporarily unavailable"
+            });
+        }
+
+        logger.LogInformation(
+            "Passkey ceremony issued for application {Application} with trace {TraceIdentifier}",
+            application,
+            HttpContext.TraceIdentifier);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Completes a WebAuthn ceremony and returns identity only after cryptographic verification.
+    /// </summary>
+    /// <param name="request">The assertion and opaque one-time flow identifier.</param>
+    /// <param name="cancellationToken">Token used to cancel the request.</param>
+    /// <returns>The verified canonical principal identity.</returns>
+    /// <response code="200">The assertion was verified and state committed.</response>
+    /// <response code="401">The assertion or ceremony was invalid.</response>
+    /// <response code="403">The service caller is not bound to the application.</response>
+    /// <response code="503">Verification could not safely commit authenticator state.</response>
+    [HttpPost("complete")]
+    [RequirePermission(AuthPermissions.ExchangeIdentities)]
+    [ProducesResponseType(typeof(PasskeyAuthCompleteResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    [RequestSizeLimit(32 * 1024)]
+    public async Task<IActionResult> Complete(
+        [FromBody] PasskeyAuthCompleteRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetBoundCaller(request.Application, out var serviceName, out var application))
+        {
+            return Forbid();
+        }
+
+        request.Application = application;
+        var result = await passkeyService.CompleteAuthenticationAsync(
+            request,
+            serviceName,
+            cancellationToken);
+        if (!result.Success)
+        {
+            var retryable = string.Equals(
+                result.Error,
+                "passkey_temporarily_unavailable",
+                StringComparison.Ordinal);
+            var statusCode = retryable
+                ? StatusCodes.Status503ServiceUnavailable
+                : StatusCodes.Status401Unauthorized;
+            logger.LogWarning(
+                "Passkey ceremony rejected for application {Application} with status {StatusCode} and trace {TraceIdentifier}",
+                application,
+                statusCode,
+                HttpContext.TraceIdentifier);
+            return StatusCode(statusCode, new ErrorResponse
+            {
+                Error = retryable ? "passkey_temporarily_unavailable" : "authentication_failed",
+                ErrorDescription = retryable
+                    ? "Passkey authentication is temporarily unavailable"
+                    : "Passkey authentication failed"
+            });
+        }
+
+        logger.LogInformation(
+            "Passkey ceremony completed for application {Application} with trace {TraceIdentifier}",
+            application,
+            HttpContext.TraceIdentifier);
+        return Ok(result);
+    }
+
+    private bool TryGetBoundCaller(
+        string? requestedApplication,
+        out string serviceName,
+        out string application)
+    {
+        var userType = User.FindFirst("user_type")?.Value;
+        serviceName = User.FindFirst("service_name")?.Value ?? string.Empty;
+        application = NormalizeSelector(requestedApplication);
+        _options.Bindings.TryGetValue(application, out var binding);
+        var allowed = string.Equals(userType, "service", StringComparison.OrdinalIgnoreCase) &&
+            application.Length > 0 &&
+            !string.IsNullOrWhiteSpace(serviceName) &&
+            binding is not null &&
+            !string.IsNullOrWhiteSpace(binding.ServiceName) &&
+            string.Equals(serviceName, binding.ServiceName, StringComparison.OrdinalIgnoreCase);
+        if (!allowed)
+        {
+            logger.LogWarning(
+                "Rejected passkey exchange for application {Application} from service caller {ServiceName}",
+                application.Length == 0 ? "invalid" : application,
+                NormalizeSelector(serviceName) is { Length: > 0 } normalizedService
+                    ? normalizedService
+                    : "invalid");
+        }
+
+        return allowed;
+    }
+
+    private static string NormalizeSelector(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return normalized is { Length: <= 64 } &&
+            normalized.All(character =>
+                character is >= 'a' and <= 'z' or >= '0' and <= '9' or '-')
+            ? normalized
+            : string.Empty;
+    }
+}

--- a/Maliev.AuthService.Api/Controllers/PasskeyAuthenticationController.cs
+++ b/Maliev.AuthService.Api/Controllers/PasskeyAuthenticationController.cs
@@ -112,10 +112,9 @@ public sealed class PasskeyAuthenticationController(
             cancellationToken);
         if (!result.Success)
         {
-            var retryable = string.Equals(
-                result.Error,
-                "passkey_temporarily_unavailable",
-                StringComparison.Ordinal);
+            var retryable = result.Error is
+                "passkey_temporarily_unavailable" or
+                "passkey_unavailable";
             var statusCode = retryable
                 ? StatusCodes.Status503ServiceUnavailable
                 : StatusCodes.Status401Unauthorized;

--- a/Maliev.AuthService.Api/Program.cs
+++ b/Maliev.AuthService.Api/Program.cs
@@ -1,9 +1,13 @@
+using Fido2NetLib;
 using Maliev.AuthService.Api.Services;
 using Maliev.AuthService.Application.Interfaces;
+using Maliev.AuthService.Domain.Entities;
 using Maliev.AuthService.Infrastructure.DbContexts;
 using Maliev.AuthService.Infrastructure.HttpClients;
+using Maliev.AuthService.Infrastructure.Security;
 using Maliev.AuthService.Infrastructure.Services;
 using MassTransit;
+using Microsoft.Extensions.Options;
 
 // Initialize bootstrap logging
 using var loggerFactory = LoggerFactory.Create(logBuilder => logBuilder.AddConsole());
@@ -123,6 +127,28 @@ try
     builder.Services.AddScoped<IGoogleIdentityNonceService, GoogleIdentityNonceService>();
     builder.Services.AddScoped<IAuthenticationService, AuthenticationService>();
     builder.Services.AddScoped<IEmailVerificationService, EmailVerificationService>();
+    builder.Services.AddOptions<PasskeyWebAuthnOptions>()
+        .Bind(builder.Configuration.GetSection("Passkey"))
+        .Validate(
+            static options => !options.Enabled || IsValidPasskeyConfiguration(options),
+            "Enabled passkey authentication requires a valid RP ID, exact HTTPS origins, and bounded ceremony settings")
+        .ValidateOnStart();
+    builder.Services.AddScoped<IFido2>(services =>
+    {
+        var options = services.GetRequiredService<IOptions<PasskeyWebAuthnOptions>>().Value;
+        return new Fido2(new Fido2Configuration
+        {
+            ServerDomain = options.RpId,
+            ServerName = options.RpName,
+            Origins = options.AllowedOrigins.ToHashSet(StringComparer.Ordinal),
+            Timeout = (uint)options.TimeoutMilliseconds,
+            ChallengeSize = options.ChallengeSize,
+            BackupEligibleCredentialPolicy = Fido2Configuration.CredentialBackupPolicy.Allowed,
+            BackedUpCredentialPolicy = Fido2Configuration.CredentialBackupPolicy.Allowed
+        });
+    });
+    builder.Services.AddScoped<IPasskeyCeremonyStore, PasskeyCeremonyStore>();
+    builder.Services.AddScoped<IPasskeyAssertionVerifier, PasskeyAssertionVerifier>();
     builder.Services.AddScoped<IPasskeyService, PasskeyService>();
 
     // Build the application
@@ -159,6 +185,60 @@ finally
 {
     loggerFactory.Dispose();
 }
+
+static bool IsValidPasskeyConfiguration(PasskeyWebAuthnOptions options)
+{
+    if (string.IsNullOrWhiteSpace(options.RpId) ||
+        string.IsNullOrWhiteSpace(options.RpName) ||
+        options.AllowedOrigins is not { Count: > 0 } ||
+        options.Bindings is not { Count: > 0 } ||
+        options.TimeoutMilliseconds is < 30_000 or > 600_000 ||
+        options.ChallengeSize is < 32 or > 64 ||
+        options.CeremonyLifetimeMinutes is < 1 or > 10)
+    {
+        return false;
+    }
+
+    if (Uri.CheckHostName(options.RpId) == UriHostNameType.Unknown ||
+        options.Bindings.Any(binding =>
+            !IsCanonicalPasskeySelector(binding.Key, 64) ||
+            binding.Value is null ||
+            !IsBoundedPasskeyServiceName(binding.Value.ServiceName) ||
+            binding.Value.PrincipalType is not (UserType.Customer or UserType.Employee)))
+    {
+        return false;
+    }
+
+    return options.AllowedOrigins.All(origin =>
+    {
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri) ||
+            !string.IsNullOrEmpty(uri.UserInfo) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment) ||
+            uri.AbsolutePath != "/" ||
+            !(uri.Scheme == Uri.UriSchemeHttps ||
+              uri.Scheme == Uri.UriSchemeHttp && uri.Host == "localhost"))
+        {
+            return false;
+        }
+
+        return string.Equals(uri.Host, options.RpId, StringComparison.OrdinalIgnoreCase) ||
+            uri.Host.EndsWith($".{options.RpId}", StringComparison.OrdinalIgnoreCase);
+    });
+}
+
+static bool IsCanonicalPasskeySelector(string value, int maximumLength) =>
+    value is { Length: > 0 } &&
+    value.Length <= maximumLength &&
+    string.Equals(value, value.Trim().ToLowerInvariant(), StringComparison.Ordinal) &&
+    value.All(character =>
+        character is >= 'a' and <= 'z' or >= '0' and <= '9' or '-');
+
+static bool IsBoundedPasskeyServiceName(string? value) =>
+    value is { Length: > 0 and <= 128 } &&
+    string.Equals(value, value.Trim(), StringComparison.Ordinal) &&
+    value.All(character =>
+        character is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '.');
 
 /// <summary>
 /// Main program class for the application

--- a/Maliev.AuthService.Api/Program.cs
+++ b/Maliev.AuthService.Api/Program.cs
@@ -194,7 +194,8 @@ static bool IsValidPasskeyConfiguration(PasskeyWebAuthnOptions options)
         options.Bindings is not { Count: > 0 } ||
         options.TimeoutMilliseconds is < 30_000 or > 600_000 ||
         options.ChallengeSize is < 32 or > 64 ||
-        options.CeremonyLifetimeMinutes is < 1 or > 10)
+        options.CeremonyLifetimeMinutes is < 1 or > 10 ||
+        options.MaxOutstandingCeremoniesPerApplication is < 1 or > 4_096)
     {
         return false;
     }

--- a/Maliev.AuthService.Api/appsettings.json
+++ b/Maliev.AuthService.Api/appsettings.json
@@ -48,6 +48,7 @@
     "TimeoutMilliseconds": 300000,
     "ChallengeSize": 32,
     "CeremonyLifetimeMinutes": 5,
+    "MaxOutstandingCeremoniesPerApplication": 512,
     "Bindings": {
       "web": {
         "ServiceName": "WebBff",

--- a/Maliev.AuthService.Api/appsettings.json
+++ b/Maliev.AuthService.Api/appsettings.json
@@ -36,6 +36,29 @@
       "Audiences": {}
     }
   },
+  "Passkey": {
+    "Enabled": false,
+    "RpId": "maliev.com",
+    "RpName": "MALIEV",
+    "AllowedOrigins": [
+      "https://maliev.com",
+      "https://www.maliev.com",
+      "https://make.maliev.com"
+    ],
+    "TimeoutMilliseconds": 300000,
+    "ChallengeSize": 32,
+    "CeremonyLifetimeMinutes": 5,
+    "Bindings": {
+      "web": {
+        "ServiceName": "WebBff",
+        "PrincipalType": "Customer"
+      },
+      "quote-engine": {
+        "ServiceName": "QuoteEngineBff",
+        "PrincipalType": "Customer"
+      }
+    }
+  },
   "CustomerService": {
     "ValidationEndpoint": "/customer/v1/customers/validate",
     "GoogleLinkOrRegisterEndpoint": "/customer/v1/customers/google/link-or-register",

--- a/Maliev.AuthService.Application/DTOs/Request/PasskeyRequests.cs
+++ b/Maliev.AuthService.Application/DTOs/Request/PasskeyRequests.cs
@@ -55,7 +55,14 @@ public class PasskeyRegistrationCompleteRequest
 public class PasskeyAuthBeginRequest
 {
     /// <summary>
-    /// Optional principal ID for discoverable credential lookup.
+    /// Server-owned MALIEV application audience.
+    /// </summary>
+    [Required]
+    [StringLength(64, MinimumLength = 1)]
+    public string Application { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Legacy principal scope. New discoverable flows must leave this value empty.
     /// </summary>
     public Guid? PrincipalId { get; set; }
 }
@@ -66,31 +73,51 @@ public class PasskeyAuthBeginRequest
 public class PasskeyAuthCompleteRequest
 {
     /// <summary>
+    /// Server-owned MALIEV application audience.
+    /// </summary>
+    [Required]
+    [StringLength(64, MinimumLength = 1)]
+    public string Application { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Opaque one-time ceremony flow identifier.
+    /// </summary>
+    [Required]
+    [StringLength(43, MinimumLength = 43)]
+    public string FlowId { get; set; } = string.Empty;
+
+    /// <summary>
     /// WebAuthn credential ID used for authentication.
     /// </summary>
     [Required]
+    [StringLength(1366, MinimumLength = 2)]
     public string CredentialId { get; set; } = string.Empty;
 
     /// <summary>
     /// Signature produced by the authenticator.
     /// </summary>
     [Required]
+    [StringLength(2732, MinimumLength = 2)]
     public string Signature { get; set; } = string.Empty;
 
     /// <summary>
     /// Authenticator data from the assertion response.
     /// </summary>
     [Required]
+    [StringLength(5464, MinimumLength = 50)]
     public string AuthenticatorData { get; set; } = string.Empty;
 
     /// <summary>
     /// Client data JSON from the assertion response.
     /// </summary>
     [Required]
+    [StringLength(10924, MinimumLength = 3)]
     public string ClientDataJson { get; set; } = string.Empty;
 
     /// <summary>
-    /// Optional user handle for credential discovery.
+    /// Required discoverable-credential user handle.
     /// </summary>
+    [Required]
+    [StringLength(88, MinimumLength = 2)]
     public string? UserHandle { get; set; }
 }

--- a/Maliev.AuthService.Application/DTOs/Response/PasskeyResponses.cs
+++ b/Maliev.AuthService.Application/DTOs/Response/PasskeyResponses.cs
@@ -37,15 +37,28 @@ public record PasskeyRegistrationCompleteResponse(bool Success, string? Error);
 /// <summary>
 /// Response containing WebAuthn credential request options for authentication.
 /// </summary>
+/// <param name="FlowId">Opaque one-time ceremony identifier.</param>
+/// <param name="ExpiresAtUtc">UTC ceremony expiration.</param>
 /// <param name="RpId">Relying Party identifier.</param>
 /// <param name="Challenge">Base64URL-encoded challenge.</param>
 /// <param name="AllowCredentials">Allowed credentials for authentication.</param>
 /// <param name="UserVerification">User verification requirement.</param>
+/// <param name="Timeout">Browser ceremony timeout in milliseconds.</param>
 public record PasskeyAuthBeginResponse(
+    string FlowId,
+    DateTime ExpiresAtUtc,
     string RpId,
-    JsonElement Challenge,
-    JsonElement AllowCredentials,
-    string? UserVerification);
+    string Challenge,
+    IReadOnlyList<PasskeyAllowedCredential> AllowCredentials,
+    string UserVerification,
+    ulong Timeout);
+
+/// <summary>
+/// An allowed public-key credential descriptor returned to the browser.
+/// </summary>
+/// <param name="Type">The WebAuthn credential type.</param>
+/// <param name="Id">The Base64URL credential identifier.</param>
+public sealed record PasskeyAllowedCredential(string Type, string Id);
 
 /// <summary>
 /// Result of passkey authentication completion.

--- a/Maliev.AuthService.Application/Interfaces/IPasskeyService.cs
+++ b/Maliev.AuthService.Application/Interfaces/IPasskeyService.cs
@@ -4,56 +4,31 @@ using Maliev.AuthService.Application.DTOs.Response;
 namespace Maliev.AuthService.Application.Interfaces;
 
 /// <summary>
-/// Service for WebAuthn passkey registration, authentication, and management.
+/// Service for verified, caller-bound WebAuthn passkey authentication.
 /// </summary>
 public interface IPasskeyService
 {
     /// <summary>
-    /// Begins WebAuthn credential registration by generating a challenge and creation options.
-    /// </summary>
-    /// <param name="principalId">The principal for whom the passkey is being registered.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Credential creation options for the WebAuthn client.</returns>
-    Task<PasskeyRegistrationBeginResponse> BeginRegistrationAsync(Guid principalId, CancellationToken ct);
-
-    /// <summary>
-    /// Completes WebAuthn credential registration by verifying the authenticator response and storing the credential.
-    /// </summary>
-    /// <param name="request">The registration completion request.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Registration result.</returns>
-    Task<PasskeyRegistrationCompleteResponse> CompleteRegistrationAsync(PasskeyRegistrationCompleteRequest request, CancellationToken ct);
-
-    /// <summary>
     /// Begins WebAuthn authentication by generating a challenge and credential request options.
     /// </summary>
-    /// <param name="principalId">Optional principal ID to scope allowed credentials.</param>
+    /// <param name="request">The server-owned application request.</param>
+    /// <param name="serviceName">The authenticated service caller.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Credential request options for the WebAuthn client.</returns>
-    Task<PasskeyAuthBeginResponse> BeginAuthenticationAsync(Guid? principalId, CancellationToken ct);
+    /// <returns>Credential request options, or <see langword="null"/> when unavailable.</returns>
+    Task<PasskeyAuthBeginResponse?> BeginAuthenticationAsync(
+        PasskeyAuthBeginRequest request,
+        string serviceName,
+        CancellationToken ct);
 
     /// <summary>
     /// Completes WebAuthn authentication by verifying the assertion signature.
     /// </summary>
     /// <param name="request">The authentication completion request.</param>
+    /// <param name="serviceName">The authenticated service caller.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Authentication result with principal information.</returns>
-    Task<PasskeyAuthCompleteResponse> CompleteAuthenticationAsync(PasskeyAuthCompleteRequest request, CancellationToken ct);
-
-    /// <summary>
-    /// Lists all passkey credentials for a principal.
-    /// </summary>
-    /// <param name="principalId">The principal identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>List of passkey credentials.</returns>
-    Task<PasskeyListResponse> ListCredentialsAsync(Guid principalId, CancellationToken ct);
-
-    /// <summary>
-    /// Deletes a passkey credential.
-    /// </summary>
-    /// <param name="credentialId">The credential identifier.</param>
-    /// <param name="principalId">The principal who owns the credential.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>True if the credential was deleted; false otherwise.</returns>
-    Task<bool> DeleteCredentialAsync(Guid credentialId, Guid principalId, CancellationToken ct);
+    Task<PasskeyAuthCompleteResponse> CompleteAuthenticationAsync(
+        PasskeyAuthCompleteRequest request,
+        string serviceName,
+        CancellationToken ct);
 }

--- a/Maliev.AuthService.Domain/Entities/PasskeyAssertionCeremony.cs
+++ b/Maliev.AuthService.Domain/Entities/PasskeyAssertionCeremony.cs
@@ -23,6 +23,9 @@ public sealed class PasskeyAssertionCeremony
     /// <summary>Gets or sets the normalized MALIEV application audience.</summary>
     public string Application { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the principal audience permitted to complete the ceremony.</summary>
+    public UserType ExpectedUserType { get; set; }
+
     /// <summary>Gets or sets the UTC creation timestamp.</summary>
     public DateTime CreatedAtUtc { get; set; }
 

--- a/Maliev.AuthService.Domain/Entities/PasskeyAssertionCeremony.cs
+++ b/Maliev.AuthService.Domain/Entities/PasskeyAssertionCeremony.cs
@@ -1,0 +1,31 @@
+namespace Maliev.AuthService.Domain.Entities;
+
+/// <summary>
+/// Stores one short-lived, caller-bound WebAuthn assertion ceremony.
+/// </summary>
+public sealed class PasskeyAssertionCeremony
+{
+    /// <summary>Gets or sets the ceremony record identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the SHA-256 hash of the browser-visible flow identifier.</summary>
+    public string FlowIdHash { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the SHA-256 hash of the server-generated challenge.</summary>
+    public string ChallengeHash { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the original FIDO2 assertion options JSON.</summary>
+    public string AssertionOptionsJson { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the normalized service caller that created the ceremony.</summary>
+    public string ServiceName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the normalized MALIEV application audience.</summary>
+    public string Application { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the UTC creation timestamp.</summary>
+    public DateTime CreatedAtUtc { get; set; }
+
+    /// <summary>Gets or sets the UTC expiration timestamp.</summary>
+    public DateTime ExpiresAtUtc { get; set; }
+}

--- a/Maliev.AuthService.Domain/Entities/PasskeyCredential.cs
+++ b/Maliev.AuthService.Domain/Entities/PasskeyCredential.cs
@@ -26,6 +26,21 @@ public class PasskeyCredential
     public string PublicKey { get; set; } = string.Empty;
 
     /// <summary>
+    /// COSE-encoded public key produced by verified WebAuthn registration.
+    /// </summary>
+    public byte[]? PublicKeyCose { get; set; }
+
+    /// <summary>
+    /// Discoverable credential user handle produced by verified registration.
+    /// </summary>
+    public byte[]? UserHandle { get; set; }
+
+    /// <summary>
+    /// Server verification schema version; zero quarantines legacy browser-authored credentials.
+    /// </summary>
+    public int RegistrationVerificationVersion { get; set; }
+
+    /// <summary>
     /// Human-readable device name.
     /// </summary>
     public string DeviceName { get; set; } = string.Empty;
@@ -39,6 +54,21 @@ public class PasskeyCredential
     /// Signature counter for clone detection.
     /// </summary>
     public int SignCount { get; set; }
+
+    /// <summary>
+    /// Full unsigned WebAuthn signature counter for a verified credential.
+    /// </summary>
+    public long? VerifiedSignCount { get; set; }
+
+    /// <summary>
+    /// Immutable backup eligibility captured by verified registration.
+    /// </summary>
+    public bool? IsBackupEligible { get; set; }
+
+    /// <summary>
+    /// Current authenticator backup state from the last verified assertion.
+    /// </summary>
+    public bool? IsBackedUp { get; set; }
 
     /// <summary>
     /// When the credential was created.

--- a/Maliev.AuthService.Infrastructure/Configurations/PasskeyAssertionCeremonyConfiguration.cs
+++ b/Maliev.AuthService.Infrastructure/Configurations/PasskeyAssertionCeremonyConfiguration.cs
@@ -1,0 +1,28 @@
+using Maliev.AuthService.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Maliev.AuthService.Infrastructure.Configurations;
+
+/// <summary>
+/// Configures short-lived passkey assertion ceremonies.
+/// </summary>
+public sealed class PasskeyAssertionCeremonyConfiguration : IEntityTypeConfiguration<PasskeyAssertionCeremony>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<PasskeyAssertionCeremony> builder)
+    {
+        builder.ToTable("passkey_assertion_ceremonies");
+        builder.HasKey(ceremony => ceremony.Id);
+        builder.Property(ceremony => ceremony.FlowIdHash).HasMaxLength(64).IsRequired();
+        builder.Property(ceremony => ceremony.ChallengeHash).HasMaxLength(64).IsRequired();
+        builder.Property(ceremony => ceremony.AssertionOptionsJson).HasColumnType("jsonb").IsRequired();
+        builder.Property(ceremony => ceremony.ServiceName).HasMaxLength(128).IsRequired();
+        builder.Property(ceremony => ceremony.Application).HasMaxLength(64).IsRequired();
+        builder.Property(ceremony => ceremony.CreatedAtUtc).IsRequired();
+        builder.Property(ceremony => ceremony.ExpiresAtUtc).IsRequired();
+        builder.HasIndex(ceremony => ceremony.FlowIdHash).IsUnique();
+        builder.HasIndex(ceremony => ceremony.ChallengeHash).IsUnique();
+        builder.HasIndex(ceremony => ceremony.ExpiresAtUtc);
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Configurations/PasskeyAssertionCeremonyConfiguration.cs
+++ b/Maliev.AuthService.Infrastructure/Configurations/PasskeyAssertionCeremonyConfiguration.cs
@@ -19,10 +19,16 @@ public sealed class PasskeyAssertionCeremonyConfiguration : IEntityTypeConfigura
         builder.Property(ceremony => ceremony.AssertionOptionsJson).HasColumnType("jsonb").IsRequired();
         builder.Property(ceremony => ceremony.ServiceName).HasMaxLength(128).IsRequired();
         builder.Property(ceremony => ceremony.Application).HasMaxLength(64).IsRequired();
+        builder.Property(ceremony => ceremony.ExpectedUserType)
+            .HasColumnName("expected_user_type")
+            .IsRequired();
         builder.Property(ceremony => ceremony.CreatedAtUtc).IsRequired();
         builder.Property(ceremony => ceremony.ExpiresAtUtc).IsRequired();
         builder.HasIndex(ceremony => ceremony.FlowIdHash).IsUnique();
         builder.HasIndex(ceremony => ceremony.ChallengeHash).IsUnique();
         builder.HasIndex(ceremony => ceremony.ExpiresAtUtc);
+        builder.ToTable(table => table.HasCheckConstraint(
+            "ck_passkey_assertion_ceremonies_expected_user_type",
+            "expected_user_type IN (1, 2)"));
     }
 }

--- a/Maliev.AuthService.Infrastructure/Configurations/PasskeyCredentialConfiguration.cs
+++ b/Maliev.AuthService.Infrastructure/Configurations/PasskeyCredentialConfiguration.cs
@@ -21,15 +21,34 @@ public class PasskeyCredentialConfiguration : IEntityTypeConfiguration<PasskeyCr
         builder.Property(e => e.PrincipalId).HasColumnName("principal_id").IsRequired();
         builder.Property(e => e.CredentialId).HasColumnName("credential_id").HasMaxLength(1024).IsRequired();
         builder.Property(e => e.PublicKey).HasColumnName("public_key").IsRequired();
+        builder.Property(e => e.PublicKeyCose).HasColumnName("public_key_cose");
+        builder.Property(e => e.UserHandle).HasColumnName("user_handle").HasMaxLength(64);
+        builder.Property(e => e.RegistrationVerificationVersion)
+            .HasColumnName("registration_verification_version")
+            .HasDefaultValue(0)
+            .IsRequired();
         builder.Property(e => e.DeviceName).HasColumnName("device_name").HasMaxLength(256).IsRequired();
         builder.Property(e => e.Aaguid).HasColumnName("aaguid").HasMaxLength(64);
         builder.Property(e => e.SignCount).HasColumnName("sign_count").IsRequired();
+        builder.Property(e => e.VerifiedSignCount).HasColumnName("verified_sign_count");
+        builder.Property(e => e.IsBackupEligible).HasColumnName("is_backup_eligible");
+        builder.Property(e => e.IsBackedUp).HasColumnName("is_backed_up");
         builder.Property(e => e.CreatedAtUtc).HasColumnName("created_at_utc").HasDefaultValueSql("NOW()");
         builder.Property(e => e.LastUsedAtUtc).HasColumnName("last_used_at_utc");
 
         // Indexes
         builder.HasIndex(e => e.PrincipalId).HasDatabaseName("idx_passkey_credentials_principal_id");
         builder.HasIndex(e => e.CredentialId).IsUnique().HasDatabaseName("idx_passkey_credentials_credential_id");
+
+        builder.ToTable(table =>
+        {
+            table.HasCheckConstraint(
+                "ck_passkey_credentials_registration_verification_version",
+                "registration_verification_version >= 0");
+            table.HasCheckConstraint(
+                "ck_passkey_credentials_verified_sign_count",
+                "verified_sign_count IS NULL OR (verified_sign_count >= 0 AND verified_sign_count <= 4294967295)");
+        });
 
         builder.Property<uint>("xmin")
             .HasColumnType("xid")

--- a/Maliev.AuthService.Infrastructure/DbContexts/AuthDbContext.cs
+++ b/Maliev.AuthService.Infrastructure/DbContexts/AuthDbContext.cs
@@ -45,6 +45,9 @@ public class AuthDbContext : DbContext
     /// <summary>Gets or sets passkey credentials.</summary>
     public DbSet<PasskeyCredential> PasskeyCredentials => Set<PasskeyCredential>();
 
+    /// <summary>Gets or sets short-lived passkey assertion ceremonies.</summary>
+    public DbSet<PasskeyAssertionCeremony> PasskeyAssertionCeremonies => Set<PasskeyAssertionCeremony>();
+
     /// <summary>Gets or sets verification tokens.</summary>
     public DbSet<VerificationToken> VerificationTokens => Set<VerificationToken>();
 

--- a/Maliev.AuthService.Infrastructure/Maliev.AuthService.Infrastructure.csproj
+++ b/Maliev.AuthService.Infrastructure/Maliev.AuthService.Infrastructure.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Fido2" Version="4.0.1" />
     <PackageReference Include="Google.Apis.Auth" Version="1.75.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Maliev.AuthService.Infrastructure/Migrations/20260711083008_AddPasskeyAssertionCeremonies.Designer.cs
+++ b/Maliev.AuthService.Infrastructure/Migrations/20260711083008_AddPasskeyAssertionCeremonies.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Maliev.AuthService.Infrastructure.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Maliev.AuthService.Infrastructure.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711083008_AddPasskeyAssertionCeremonies")]
+    partial class AddPasskeyAssertionCeremonies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Maliev.AuthService.Infrastructure/Migrations/20260711083008_AddPasskeyAssertionCeremonies.cs
+++ b/Maliev.AuthService.Infrastructure/Migrations/20260711083008_AddPasskeyAssertionCeremonies.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maliev.AuthService.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPasskeyAssertionCeremonies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "passkey_assertion_ceremonies",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    flow_id_hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    challenge_hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    assertion_options_json = table.Column<string>(type: "jsonb", nullable: false),
+                    service_name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    application = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    created_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    expires_at_utc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_passkey_assertion_ceremonies", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_passkey_assertion_ceremonies_challenge_hash",
+                table: "passkey_assertion_ceremonies",
+                column: "challenge_hash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_passkey_assertion_ceremonies_expires_at_utc",
+                table: "passkey_assertion_ceremonies",
+                column: "expires_at_utc");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_passkey_assertion_ceremonies_flow_id_hash",
+                table: "passkey_assertion_ceremonies",
+                column: "flow_id_hash",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "passkey_assertion_ceremonies");
+        }
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Migrations/20260711083547_QuarantineUnverifiedPasskeyCredentials.Designer.cs
+++ b/Maliev.AuthService.Infrastructure/Migrations/20260711083547_QuarantineUnverifiedPasskeyCredentials.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Maliev.AuthService.Infrastructure.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Maliev.AuthService.Infrastructure.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711083547_QuarantineUnverifiedPasskeyCredentials")]
+    partial class QuarantineUnverifiedPasskeyCredentials
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Maliev.AuthService.Infrastructure/Migrations/20260711083547_QuarantineUnverifiedPasskeyCredentials.cs
+++ b/Maliev.AuthService.Infrastructure/Migrations/20260711083547_QuarantineUnverifiedPasskeyCredentials.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maliev.AuthService.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class QuarantineUnverifiedPasskeyCredentials : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_backed_up",
+                table: "passkey_credentials",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_backup_eligible",
+                table: "passkey_credentials",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "public_key_cose",
+                table: "passkey_credentials",
+                type: "bytea",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "registration_verification_version",
+                table: "passkey_credentials",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "user_handle",
+                table: "passkey_credentials",
+                type: "bytea",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "verified_sign_count",
+                table: "passkey_credentials",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_passkey_credentials_registration_verification_version",
+                table: "passkey_credentials",
+                sql: "registration_verification_version >= 0");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_passkey_credentials_verified_sign_count",
+                table: "passkey_credentials",
+                sql: "verified_sign_count IS NULL OR (verified_sign_count >= 0 AND verified_sign_count <= 4294967295)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_passkey_credentials_registration_verification_version",
+                table: "passkey_credentials");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_passkey_credentials_verified_sign_count",
+                table: "passkey_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "is_backed_up",
+                table: "passkey_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "is_backup_eligible",
+                table: "passkey_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "public_key_cose",
+                table: "passkey_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "registration_verification_version",
+                table: "passkey_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "user_handle",
+                table: "passkey_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "verified_sign_count",
+                table: "passkey_credentials");
+        }
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Migrations/20260711090611_BindPasskeyCeremonyPrincipalAudience.Designer.cs
+++ b/Maliev.AuthService.Infrastructure/Migrations/20260711090611_BindPasskeyCeremonyPrincipalAudience.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Maliev.AuthService.Infrastructure.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Maliev.AuthService.Infrastructure.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711090611_BindPasskeyCeremonyPrincipalAudience")]
+    partial class BindPasskeyCeremonyPrincipalAudience
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Maliev.AuthService.Infrastructure/Migrations/20260711090611_BindPasskeyCeremonyPrincipalAudience.cs
+++ b/Maliev.AuthService.Infrastructure/Migrations/20260711090611_BindPasskeyCeremonyPrincipalAudience.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maliev.AuthService.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class BindPasskeyCeremonyPrincipalAudience : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "expected_user_type",
+                table: "passkey_assertion_ceremonies",
+                type: "integer",
+                nullable: true);
+
+            // Ceremonies are short-lived authentication challenges. Existing rows predate
+            // principal-audience binding and must be invalidated instead of being guessed.
+            migrationBuilder.Sql("DELETE FROM passkey_assertion_ceremonies;");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "expected_user_type",
+                table: "passkey_assertion_ceremonies",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_passkey_assertion_ceremonies_expected_user_type",
+                table: "passkey_assertion_ceremonies",
+                sql: "expected_user_type IN (1, 2)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_passkey_assertion_ceremonies_expected_user_type",
+                table: "passkey_assertion_ceremonies");
+
+            migrationBuilder.DropColumn(
+                name: "expected_user_type",
+                table: "passkey_assertion_ceremonies");
+        }
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Security/IPasskeyAssertionVerifier.cs
+++ b/Maliev.AuthService.Infrastructure/Security/IPasskeyAssertionVerifier.cs
@@ -1,0 +1,104 @@
+namespace Maliev.AuthService.Infrastructure.Security;
+
+/// <summary>
+/// Verifies a WebAuthn assertion against server-owned ceremony and credential state.
+/// </summary>
+public interface IPasskeyAssertionVerifier
+{
+    /// <summary>Verifies an assertion and returns the updated authenticator state.</summary>
+    /// <param name="input">The assertion and server-owned verification state.</param>
+    /// <param name="cancellationToken">Token used to cancel verification.</param>
+    /// <returns>The fail-closed verification result.</returns>
+    Task<PasskeyAssertionVerificationResult> VerifyAsync(
+        PasskeyAssertionVerificationInput input,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Contains the browser assertion plus server-owned options and credential state.
+/// </summary>
+/// <param name="AssertionOptionsJson">The original FIDO2 assertion options issued by the server.</param>
+/// <param name="CredentialId">The canonical Base64URL credential identifier returned by the browser.</param>
+/// <param name="AuthenticatorData">The Base64URL authenticator data.</param>
+/// <param name="ClientDataJson">The Base64URL raw client data JSON.</param>
+/// <param name="Signature">The Base64URL authenticator signature.</param>
+/// <param name="UserHandle">The Base64URL discoverable-credential user handle.</param>
+/// <param name="StoredCredentialId">The credential identifier stored after verified registration.</param>
+/// <param name="StoredPublicKeyCose">The COSE public key stored after verified registration.</param>
+/// <param name="StoredUserHandle">The user handle stored after verified registration.</param>
+/// <param name="StoredSignCount">The last committed authenticator signature counter.</param>
+/// <param name="StoredBackupEligible">The immutable backup-eligibility state from registration.</param>
+public sealed record PasskeyAssertionVerificationInput(
+    string AssertionOptionsJson,
+    string CredentialId,
+    string AuthenticatorData,
+    string ClientDataJson,
+    string Signature,
+    string? UserHandle,
+    byte[] StoredCredentialId,
+    byte[] StoredPublicKeyCose,
+    byte[] StoredUserHandle,
+    uint StoredSignCount,
+    bool StoredBackupEligible);
+
+/// <summary>
+/// Represents the outcome of passkey assertion verification.
+/// </summary>
+/// <param name="Success">Whether every MALIEV and WebAuthn check succeeded.</param>
+/// <param name="SignCount">The verified authenticator signature counter.</param>
+/// <param name="IsBackedUp">The current authenticator backup state.</param>
+/// <param name="Failure">The internal fail-closed category.</param>
+public sealed record PasskeyAssertionVerificationResult(
+    bool Success,
+    uint SignCount,
+    bool IsBackedUp,
+    PasskeyAssertionFailure Failure)
+{
+    /// <summary>Creates a failed verification result without authenticated state.</summary>
+    /// <param name="failure">The internal failure category.</param>
+    /// <returns>A failed result.</returns>
+    public static PasskeyAssertionVerificationResult Failed(PasskeyAssertionFailure failure) =>
+        new(false, 0, false, failure);
+}
+
+/// <summary>
+/// Internal fail-closed categories used by tests and security telemetry.
+/// </summary>
+public enum PasskeyAssertionFailure
+{
+    /// <summary>No failure occurred.</summary>
+    None = 0,
+
+    /// <summary>A Base64URL field was malformed, non-canonical, or outside its bound.</summary>
+    InvalidEncoding,
+
+    /// <summary>The stored assertion options were invalid or did not match current policy.</summary>
+    InvalidOptions,
+
+    /// <summary>The signed browser client data was malformed or inconsistent.</summary>
+    InvalidClientData,
+
+    /// <summary>The signed browser origin was not an exact allowed origin.</summary>
+    InvalidOrigin,
+
+    /// <summary>The browser reported a cross-origin ceremony.</summary>
+    CrossOriginNotAllowed,
+
+    /// <summary>The authenticator flags were missing, reserved, or unsolicited.</summary>
+    InvalidAuthenticatorFlags,
+
+    /// <summary>The credential's immutable backup eligibility changed.</summary>
+    BackupEligibilityChanged,
+
+    /// <summary>The authenticator signature counter regressed or reset unexpectedly.</summary>
+    InvalidSignCount,
+
+    /// <summary>The discoverable credential user handle was missing or did not match.</summary>
+    InvalidUserHandle,
+
+    /// <summary>The browser credential identifier did not match stored credential state.</summary>
+    InvalidCredential,
+
+    /// <summary>The standards-compliant FIDO2 verifier rejected the assertion.</summary>
+    VerificationFailed
+}

--- a/Maliev.AuthService.Infrastructure/Security/IPasskeyCeremonyStore.cs
+++ b/Maliev.AuthService.Infrastructure/Security/IPasskeyCeremonyStore.cs
@@ -1,0 +1,46 @@
+namespace Maliev.AuthService.Infrastructure.Security;
+
+/// <summary>
+/// Issues and atomically consumes caller-bound WebAuthn assertion ceremonies.
+/// </summary>
+public interface IPasskeyCeremonyStore
+{
+    /// <summary>Persists a new assertion ceremony.</summary>
+    /// <param name="serviceName">The authenticated service caller.</param>
+    /// <param name="application">The normalized application audience.</param>
+    /// <param name="assertionOptionsJson">The original FIDO2 assertion options.</param>
+    /// <param name="challenge">The server-generated challenge.</param>
+    /// <param name="cancellationToken">Token used to cancel persistence.</param>
+    /// <returns>The browser-visible flow ID and expiration.</returns>
+    Task<PasskeyCeremonyIssue> IssueAsync(
+        string serviceName,
+        string application,
+        string assertionOptionsJson,
+        byte[] challenge,
+        CancellationToken cancellationToken);
+
+    /// <summary>Atomically consumes a matching, unexpired assertion ceremony.</summary>
+    /// <param name="flowId">The opaque flow identifier returned at issue time.</param>
+    /// <param name="serviceName">The authenticated service caller.</param>
+    /// <param name="application">The normalized application audience.</param>
+    /// <param name="cancellationToken">Token used to cancel persistence.</param>
+    /// <returns>The server-owned ceremony state, or <see langword="null"/>.</returns>
+    Task<PasskeyCeremonyState?> ConsumeAsync(
+        string flowId,
+        string serviceName,
+        string application,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Contains the browser-visible result of issuing an assertion ceremony.
+/// </summary>
+/// <param name="FlowId">The random, opaque flow identifier.</param>
+/// <param name="ExpiresAtUtc">The UTC expiration timestamp.</param>
+public sealed record PasskeyCeremonyIssue(string FlowId, DateTime ExpiresAtUtc);
+
+/// <summary>
+/// Contains the server-owned state recovered by a successful one-time consume.
+/// </summary>
+/// <param name="AssertionOptionsJson">The original FIDO2 assertion options.</param>
+public sealed record PasskeyCeremonyState(string AssertionOptionsJson);

--- a/Maliev.AuthService.Infrastructure/Security/IPasskeyCeremonyStore.cs
+++ b/Maliev.AuthService.Infrastructure/Security/IPasskeyCeremonyStore.cs
@@ -44,6 +44,11 @@ public interface IPasskeyCeremonyStore
 public sealed record PasskeyCeremonyIssue(string FlowId, DateTime ExpiresAtUtc);
 
 /// <summary>
+/// Indicates that a trusted caller/application boundary has reached its outstanding ceremony quota.
+/// </summary>
+public sealed class PasskeyCeremonyCapacityExceededException : Exception;
+
+/// <summary>
 /// Contains the server-owned state recovered by a successful one-time consume.
 /// </summary>
 /// <param name="AssertionOptionsJson">The original FIDO2 assertion options.</param>

--- a/Maliev.AuthService.Infrastructure/Security/IPasskeyCeremonyStore.cs
+++ b/Maliev.AuthService.Infrastructure/Security/IPasskeyCeremonyStore.cs
@@ -1,3 +1,5 @@
+using Maliev.AuthService.Domain.Entities;
+
 namespace Maliev.AuthService.Infrastructure.Security;
 
 /// <summary>
@@ -8,6 +10,7 @@ public interface IPasskeyCeremonyStore
     /// <summary>Persists a new assertion ceremony.</summary>
     /// <param name="serviceName">The authenticated service caller.</param>
     /// <param name="application">The normalized application audience.</param>
+    /// <param name="expectedUserType">The principal audience permitted to complete the ceremony.</param>
     /// <param name="assertionOptionsJson">The original FIDO2 assertion options.</param>
     /// <param name="challenge">The server-generated challenge.</param>
     /// <param name="cancellationToken">Token used to cancel persistence.</param>
@@ -15,6 +18,7 @@ public interface IPasskeyCeremonyStore
     Task<PasskeyCeremonyIssue> IssueAsync(
         string serviceName,
         string application,
+        UserType expectedUserType,
         string assertionOptionsJson,
         byte[] challenge,
         CancellationToken cancellationToken);
@@ -43,4 +47,7 @@ public sealed record PasskeyCeremonyIssue(string FlowId, DateTime ExpiresAtUtc);
 /// Contains the server-owned state recovered by a successful one-time consume.
 /// </summary>
 /// <param name="AssertionOptionsJson">The original FIDO2 assertion options.</param>
-public sealed record PasskeyCeremonyState(string AssertionOptionsJson);
+/// <param name="ExpectedUserType">The principal audience bound at ceremony issue time.</param>
+public sealed record PasskeyCeremonyState(
+    string AssertionOptionsJson,
+    UserType ExpectedUserType);

--- a/Maliev.AuthService.Infrastructure/Security/PasskeyAssertionVerifier.cs
+++ b/Maliev.AuthService.Infrastructure/Security/PasskeyAssertionVerifier.cs
@@ -1,0 +1,296 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Fido2NetLib;
+using Fido2NetLib.Exceptions;
+using Fido2NetLib.Objects;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Maliev.AuthService.Infrastructure.Security;
+
+/// <summary>
+/// Applies MALIEV's exact-origin and authenticator-state policy around the FIDO2 verifier.
+/// </summary>
+public sealed class PasskeyAssertionVerifier(
+    IFido2 fido2,
+    IOptions<PasskeyWebAuthnOptions> options,
+    ILogger<PasskeyAssertionVerifier> logger) : IPasskeyAssertionVerifier
+{
+    private const byte UserPresent = 0x01;
+    private const byte UserVerified = 0x04;
+    private const byte BackupEligible = 0x08;
+    private const byte BackupState = 0x10;
+    private const byte AllowedFlags = UserPresent | UserVerified | BackupEligible | BackupState;
+    private readonly PasskeyWebAuthnOptions _options = options.Value;
+
+    /// <inheritdoc />
+    public async Task<PasskeyAssertionVerificationResult> VerifyAsync(
+        PasskeyAssertionVerificationInput input,
+        CancellationToken cancellationToken)
+    {
+        if (input.StoredCredentialId is not { Length: >= 1 and <= 1024 } ||
+            input.StoredPublicKeyCose is not { Length: >= 1 and <= 4096 })
+        {
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.InvalidCredential);
+        }
+
+        if (input.StoredUserHandle is not { Length: >= 1 and <= 64 })
+        {
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.InvalidUserHandle);
+        }
+
+        if (!TryDecodeCanonicalBase64Url(input.CredentialId, 1, 1024, out var credentialId) ||
+            !TryDecodeCanonicalBase64Url(input.AuthenticatorData, 37, 4096, out var authenticatorData) ||
+            !TryDecodeCanonicalBase64Url(input.ClientDataJson, 2, 8192, out var clientDataJson) ||
+            !TryDecodeCanonicalBase64Url(input.Signature, 1, 2048, out var signature))
+        {
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.InvalidEncoding);
+        }
+
+        if (string.IsNullOrWhiteSpace(input.UserHandle))
+        {
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.InvalidUserHandle);
+        }
+
+        if (!TryDecodeCanonicalBase64Url(input.UserHandle, 1, 64, out var userHandle))
+        {
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.InvalidEncoding);
+        }
+
+        if (!FixedTimeEquals(credentialId, input.StoredCredentialId))
+        {
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.InvalidCredential);
+        }
+
+        if (!FixedTimeEquals(userHandle, input.StoredUserHandle))
+        {
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.InvalidUserHandle);
+        }
+
+        if (!TryReadAndValidateOptions(input.AssertionOptionsJson, out var assertionOptions))
+        {
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.InvalidOptions);
+        }
+
+        var clientDataFailure = ValidateClientData(clientDataJson, assertionOptions!.Challenge);
+        if (clientDataFailure != PasskeyAssertionFailure.None)
+        {
+            return PasskeyAssertionVerificationResult.Failed(clientDataFailure);
+        }
+
+        var stateFailure = ValidateAuthenticatorState(
+            authenticatorData,
+            input.StoredSignCount,
+            input.StoredBackupEligible);
+        if (stateFailure != PasskeyAssertionFailure.None)
+        {
+            return PasskeyAssertionVerificationResult.Failed(stateFailure);
+        }
+
+        try
+        {
+            var response = new AuthenticatorAssertionRawResponse
+            {
+                Id = input.CredentialId,
+                RawId = credentialId,
+                Type = PublicKeyCredentialType.PublicKey,
+                ClientExtensionResults = new AuthenticationExtensionsClientOutputs(),
+                Response = new AuthenticatorAssertionRawResponse.AssertionResponse
+                {
+                    AuthenticatorData = authenticatorData,
+                    ClientDataJson = clientDataJson,
+                    Signature = signature,
+                    UserHandle = userHandle
+                }
+            };
+            IsUserHandleOwnerOfCredentialIdAsync ownsCredential = (parameters, _) =>
+                Task.FromResult(
+                    FixedTimeEquals(parameters.CredentialId, input.StoredCredentialId) &&
+                    FixedTimeEquals(parameters.UserHandle, input.StoredUserHandle));
+            var result = await fido2.MakeAssertionAsync(new MakeAssertionParams
+            {
+                AssertionResponse = response,
+                OriginalOptions = assertionOptions,
+                StoredPublicKey = input.StoredPublicKeyCose,
+                StoredSignatureCounter = input.StoredSignCount,
+                IsUserHandleOwnerOfCredentialIdCallback = ownsCredential
+            }, cancellationToken: cancellationToken);
+
+            return new PasskeyAssertionVerificationResult(
+                true,
+                result.SignCount,
+                result.IsBackedUp,
+                PasskeyAssertionFailure.None);
+        }
+        catch (Fido2VerificationException exception)
+        {
+            logger.LogWarning(
+                "Passkey assertion rejected by FIDO2 verifier with category {FailureCategory}",
+                exception.Code);
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.VerificationFailed);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                "Passkey assertion failed closed with exception type {ExceptionType}",
+                exception.GetType().Name);
+            return PasskeyAssertionVerificationResult.Failed(PasskeyAssertionFailure.VerificationFailed);
+        }
+    }
+
+    private bool TryReadAndValidateOptions(string json, out AssertionOptions? assertionOptions)
+    {
+        assertionOptions = null;
+        if (string.IsNullOrWhiteSpace(json) || json.Length > 16_384)
+        {
+            return false;
+        }
+
+        try
+        {
+            assertionOptions = AssertionOptions.FromJson(json);
+            return assertionOptions is not null &&
+                assertionOptions.Challenge is { Length: >= 32 and <= 64 } &&
+                _options.AllowedOrigins is { Count: > 0 } &&
+                string.Equals(assertionOptions.RpId, _options.RpId, StringComparison.Ordinal) &&
+                assertionOptions.UserVerification == UserVerificationRequirement.Required &&
+                assertionOptions.AllowCredentials.Count == 0 &&
+                assertionOptions.Extensions is null;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private PasskeyAssertionFailure ValidateClientData(byte[] clientDataJson, byte[] expectedChallenge)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(clientDataJson, new JsonDocumentOptions
+            {
+                AllowTrailingCommas = false,
+                CommentHandling = JsonCommentHandling.Disallow,
+                MaxDepth = 8
+            });
+            if (document.RootElement.ValueKind != JsonValueKind.Object ||
+                HasDuplicateProperties(document.RootElement) ||
+                !TryGetRequiredString(document.RootElement, "type", out var type) ||
+                !string.Equals(type, "webauthn.get", StringComparison.Ordinal) ||
+                !TryGetRequiredString(document.RootElement, "challenge", out var challenge) ||
+                !TryDecodeCanonicalBase64Url(challenge, 32, 64, out var challengeBytes) ||
+                !FixedTimeEquals(challengeBytes, expectedChallenge))
+            {
+                return PasskeyAssertionFailure.InvalidClientData;
+            }
+
+            if (!TryGetRequiredString(document.RootElement, "origin", out var origin) ||
+                !_options.AllowedOrigins.Contains(origin, StringComparer.Ordinal))
+            {
+                return PasskeyAssertionFailure.InvalidOrigin;
+            }
+
+            if (document.RootElement.TryGetProperty("topOrigin", out _) ||
+                document.RootElement.TryGetProperty("crossOrigin", out var crossOrigin) &&
+                (crossOrigin.ValueKind != JsonValueKind.False))
+            {
+                return PasskeyAssertionFailure.CrossOriginNotAllowed;
+            }
+
+            return PasskeyAssertionFailure.None;
+        }
+        catch (JsonException)
+        {
+            return PasskeyAssertionFailure.InvalidClientData;
+        }
+    }
+
+    private static PasskeyAssertionFailure ValidateAuthenticatorState(
+        byte[] authenticatorData,
+        uint storedSignCount,
+        bool storedBackupEligible)
+    {
+        var flags = authenticatorData[32];
+        if ((flags & ~AllowedFlags) != 0 ||
+            (flags & (UserPresent | UserVerified)) != (UserPresent | UserVerified) ||
+            (flags & BackupState) != 0 && (flags & BackupEligible) == 0)
+        {
+            return PasskeyAssertionFailure.InvalidAuthenticatorFlags;
+        }
+
+        var backupEligible = (flags & BackupEligible) != 0;
+        if (backupEligible != storedBackupEligible)
+        {
+            return PasskeyAssertionFailure.BackupEligibilityChanged;
+        }
+
+        var signCount = BinaryPrimitives.ReadUInt32BigEndian(authenticatorData.AsSpan(33, 4));
+        if (storedSignCount > 0 && signCount == 0 ||
+            signCount > 0 && signCount <= storedSignCount)
+        {
+            return PasskeyAssertionFailure.InvalidSignCount;
+        }
+
+        return PasskeyAssertionFailure.None;
+    }
+
+    private static bool TryDecodeCanonicalBase64Url(
+        string? value,
+        int minimumBytes,
+        int maximumBytes,
+        out byte[] decoded)
+    {
+        decoded = [];
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.Length > ((maximumBytes + 2) / 3 * 4) ||
+            value.Contains('=') ||
+            value.Contains('+') ||
+            value.Contains('/') ||
+            value.Any(character =>
+                !(character is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '_')))
+        {
+            return false;
+        }
+
+        try
+        {
+            var padded = value.Replace('-', '+').Replace('_', '/');
+            padded += new string('=', (4 - padded.Length % 4) % 4);
+            decoded = Convert.FromBase64String(padded);
+            return decoded.Length >= minimumBytes &&
+                decoded.Length <= maximumBytes &&
+                string.Equals(ToBase64Url(decoded), value, StringComparison.Ordinal);
+        }
+        catch (FormatException)
+        {
+            decoded = [];
+            return false;
+        }
+    }
+
+    private static bool HasDuplicateProperties(JsonElement element)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        return element.EnumerateObject().Any(property => !names.Add(property.Name));
+    }
+
+    private static bool TryGetRequiredString(JsonElement element, string propertyName, out string value)
+    {
+        value = string.Empty;
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = property.GetString() ?? string.Empty;
+        return value.Length > 0;
+    }
+
+    private static bool FixedTimeEquals(byte[] left, byte[] right) =>
+        left.Length == right.Length && CryptographicOperations.FixedTimeEquals(left, right);
+
+    private static string ToBase64Url(byte[] value) =>
+        Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/Maliev.AuthService.Infrastructure/Security/PasskeyCeremonyStore.cs
+++ b/Maliev.AuthService.Infrastructure/Security/PasskeyCeremonyStore.cs
@@ -24,12 +24,20 @@ public sealed class PasskeyCeremonyStore(
     public async Task<PasskeyCeremonyIssue> IssueAsync(
         string serviceName,
         string application,
+        UserType expectedUserType,
         string assertionOptionsJson,
         byte[] challenge,
         CancellationToken cancellationToken)
     {
         var caller = NormalizeBounded(serviceName, 128, nameof(serviceName));
         var audience = NormalizeBounded(application, 64, nameof(application));
+        if (expectedUserType is not (UserType.Customer or UserType.Employee))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(expectedUserType),
+                "A supported principal audience is required.");
+        }
+
         if (string.IsNullOrWhiteSpace(assertionOptionsJson) || assertionOptionsJson.Length > 16_384)
         {
             throw new ArgumentException("Assertion options are required and must be bounded.", nameof(assertionOptionsJson));
@@ -54,6 +62,7 @@ public sealed class PasskeyCeremonyStore(
             AssertionOptionsJson = assertionOptionsJson,
             ServiceName = caller,
             Application = audience,
+            ExpectedUserType = expectedUserType,
             CreatedAtUtc = now,
             ExpiresAtUtc = now.Add(_lifetime)
         };
@@ -98,7 +107,8 @@ public sealed class PasskeyCeremonyStore(
             .Select(existing => new
             {
                 existing.Id,
-                existing.AssertionOptionsJson
+                existing.AssertionOptionsJson,
+                existing.ExpectedUserType
             })
             .SingleOrDefaultAsync(cancellationToken);
         if (ceremony is null)
@@ -115,7 +125,9 @@ public sealed class PasskeyCeremonyStore(
                 existing.ExpiresAtUtc > now)
             .ExecuteDeleteAsync(cancellationToken);
         return deleted == 1
-            ? new PasskeyCeremonyState(ceremony.AssertionOptionsJson)
+            ? new PasskeyCeremonyState(
+                ceremony.AssertionOptionsJson,
+                ceremony.ExpectedUserType)
             : null;
     }
 

--- a/Maliev.AuthService.Infrastructure/Security/PasskeyCeremonyStore.cs
+++ b/Maliev.AuthService.Infrastructure/Security/PasskeyCeremonyStore.cs
@@ -1,8 +1,11 @@
+using System.Buffers.Binary;
+using System.Data;
 using System.Security.Cryptography;
 using System.Text;
 using Maliev.AuthService.Domain.Entities;
 using Maliev.AuthService.Infrastructure.DbContexts;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Options;
 
 namespace Maliev.AuthService.Infrastructure.Security;
@@ -19,6 +22,10 @@ public sealed class PasskeyCeremonyStore(
         options.Value.CeremonyLifetimeMinutes,
         1,
         10));
+    private readonly int _maxOutstandingCeremonies = Math.Clamp(
+        options.Value.MaxOutstandingCeremoniesPerApplication,
+        1,
+        4_096);
 
     /// <inheritdoc />
     public async Task<PasskeyCeremonyIssue> IssueAsync(
@@ -49,10 +56,6 @@ public sealed class PasskeyCeremonyStore(
         }
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
-        await dbContext.PasskeyAssertionCeremonies
-            .Where(existing => existing.ExpiresAtUtc <= now)
-            .ExecuteDeleteAsync(cancellationToken);
-
         var flowId = ToBase64Url(RandomNumberGenerator.GetBytes(32));
         var ceremony = new PasskeyAssertionCeremony
         {
@@ -66,9 +69,41 @@ public sealed class PasskeyCeremonyStore(
             CreatedAtUtc = now,
             ExpiresAtUtc = now.Add(_lifetime)
         };
-        dbContext.PasskeyAssertionCeremonies.Add(ceremony);
-        await dbContext.SaveChangesAsync(cancellationToken);
-        return new PasskeyCeremonyIssue(flowId, ceremony.ExpiresAtUtc);
+        var issue = new PasskeyCeremonyIssue(flowId, ceremony.ExpiresAtUtc);
+        var executionStrategy = dbContext.Database.CreateExecutionStrategy();
+        return await executionStrategy.ExecuteInTransactionAsync(
+            async operationCancellationToken =>
+            {
+                await dbContext.PasskeyAssertionCeremonies
+                    .Where(existing => existing.ExpiresAtUtc <= now)
+                    .ExecuteDeleteAsync(operationCancellationToken);
+                var boundaryLockKey = CreateBoundaryLockKey(caller, audience);
+                await dbContext.Database.ExecuteSqlInterpolatedAsync(
+                    $"SELECT pg_advisory_xact_lock({boundaryLockKey})",
+                    operationCancellationToken);
+                var outstandingCount = await dbContext.PasskeyAssertionCeremonies
+                    .CountAsync(existing =>
+                        existing.ServiceName == caller &&
+                        existing.Application == audience &&
+                        existing.ExpiresAtUtc > now,
+                        operationCancellationToken);
+                if (outstandingCount >= _maxOutstandingCeremonies)
+                {
+                    throw new PasskeyCeremonyCapacityExceededException();
+                }
+
+                dbContext.PasskeyAssertionCeremonies.Add(ceremony);
+                await dbContext.SaveChangesAsync(operationCancellationToken);
+                return issue;
+            },
+            verifySucceeded: verificationCancellationToken =>
+                dbContext.PasskeyAssertionCeremonies
+                    .AsNoTracking()
+                    .AnyAsync(
+                        existing => existing.FlowIdHash == ceremony.FlowIdHash,
+                        verificationCancellationToken),
+            IsolationLevel.ReadCommitted,
+            cancellationToken);
     }
 
     /// <inheritdoc />
@@ -169,6 +204,12 @@ public sealed class PasskeyCeremonyStore(
     }
 
     private static string Hash(byte[] value) => Convert.ToHexString(SHA256.HashData(value));
+
+    private static long CreateBoundaryLockKey(string serviceName, string application)
+    {
+        var boundary = Encoding.UTF8.GetBytes($"{serviceName}\u001f{application}");
+        return BinaryPrimitives.ReadInt64BigEndian(SHA256.HashData(boundary));
+    }
 
     private static string ToBase64Url(byte[] value) =>
         Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');

--- a/Maliev.AuthService.Infrastructure/Security/PasskeyCeremonyStore.cs
+++ b/Maliev.AuthService.Infrastructure/Security/PasskeyCeremonyStore.cs
@@ -1,0 +1,163 @@
+using System.Security.Cryptography;
+using System.Text;
+using Maliev.AuthService.Domain.Entities;
+using Maliev.AuthService.Infrastructure.DbContexts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Maliev.AuthService.Infrastructure.Security;
+
+/// <summary>
+/// Persists only hashes of browser-visible ceremony values and consumes flows with one atomic delete.
+/// </summary>
+public sealed class PasskeyCeremonyStore(
+    AuthDbContext dbContext,
+    IOptions<PasskeyWebAuthnOptions> options,
+    TimeProvider timeProvider) : IPasskeyCeremonyStore
+{
+    private readonly TimeSpan _lifetime = TimeSpan.FromMinutes(Math.Clamp(
+        options.Value.CeremonyLifetimeMinutes,
+        1,
+        10));
+
+    /// <inheritdoc />
+    public async Task<PasskeyCeremonyIssue> IssueAsync(
+        string serviceName,
+        string application,
+        string assertionOptionsJson,
+        byte[] challenge,
+        CancellationToken cancellationToken)
+    {
+        var caller = NormalizeBounded(serviceName, 128, nameof(serviceName));
+        var audience = NormalizeBounded(application, 64, nameof(application));
+        if (string.IsNullOrWhiteSpace(assertionOptionsJson) || assertionOptionsJson.Length > 16_384)
+        {
+            throw new ArgumentException("Assertion options are required and must be bounded.", nameof(assertionOptionsJson));
+        }
+
+        if (challenge is not { Length: >= 32 and <= 64 })
+        {
+            throw new ArgumentException("A 32 to 64 byte challenge is required.", nameof(challenge));
+        }
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        await dbContext.PasskeyAssertionCeremonies
+            .Where(existing => existing.ExpiresAtUtc <= now)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        var flowId = ToBase64Url(RandomNumberGenerator.GetBytes(32));
+        var ceremony = new PasskeyAssertionCeremony
+        {
+            Id = Guid.NewGuid(),
+            FlowIdHash = Hash(Encoding.UTF8.GetBytes(flowId)),
+            ChallengeHash = Hash(challenge),
+            AssertionOptionsJson = assertionOptionsJson,
+            ServiceName = caller,
+            Application = audience,
+            CreatedAtUtc = now,
+            ExpiresAtUtc = now.Add(_lifetime)
+        };
+        dbContext.PasskeyAssertionCeremonies.Add(ceremony);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return new PasskeyCeremonyIssue(flowId, ceremony.ExpiresAtUtc);
+    }
+
+    /// <inheritdoc />
+    public async Task<PasskeyCeremonyState?> ConsumeAsync(
+        string flowId,
+        string serviceName,
+        string application,
+        CancellationToken cancellationToken)
+    {
+        if (!IsCanonicalFlowId(flowId))
+        {
+            return null;
+        }
+
+        string caller;
+        string audience;
+        try
+        {
+            caller = NormalizeBounded(serviceName, 128, nameof(serviceName));
+            audience = NormalizeBounded(application, 64, nameof(application));
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+
+        var hash = Hash(Encoding.UTF8.GetBytes(flowId));
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var ceremony = await dbContext.PasskeyAssertionCeremonies
+            .AsNoTracking()
+            .Where(existing =>
+                existing.FlowIdHash == hash &&
+                existing.ServiceName == caller &&
+                existing.Application == audience &&
+                existing.ExpiresAtUtc > now)
+            .Select(existing => new
+            {
+                existing.Id,
+                existing.AssertionOptionsJson
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+        if (ceremony is null)
+        {
+            return null;
+        }
+
+        var deleted = await dbContext.PasskeyAssertionCeremonies
+            .Where(existing =>
+                existing.Id == ceremony.Id &&
+                existing.FlowIdHash == hash &&
+                existing.ServiceName == caller &&
+                existing.Application == audience &&
+                existing.ExpiresAtUtc > now)
+            .ExecuteDeleteAsync(cancellationToken);
+        return deleted == 1
+            ? new PasskeyCeremonyState(ceremony.AssertionOptionsJson)
+            : null;
+    }
+
+    private static string NormalizeBounded(string value, int maximumLength, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("A non-empty boundary value is required.", parameterName);
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        if (normalized.Length > maximumLength)
+        {
+            throw new ArgumentException("The boundary value exceeds its maximum length.", parameterName);
+        }
+
+        return normalized;
+    }
+
+    private static bool IsCanonicalFlowId(string value)
+    {
+        if (value is not { Length: 43 } ||
+            value.Any(character =>
+                !(character is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '_')))
+        {
+            return false;
+        }
+
+        try
+        {
+            var padded = value.Replace('-', '+').Replace('_', '/') + "=";
+            var decoded = Convert.FromBase64String(padded);
+            return decoded.Length == 32 && string.Equals(ToBase64Url(decoded), value, StringComparison.Ordinal);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static string Hash(byte[] value) => Convert.ToHexString(SHA256.HashData(value));
+
+    private static string ToBase64Url(byte[] value) =>
+        Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/Maliev.AuthService.Infrastructure/Security/PasskeyWebAuthnOptions.cs
+++ b/Maliev.AuthService.Infrastructure/Security/PasskeyWebAuthnOptions.cs
@@ -28,6 +28,9 @@ public sealed class PasskeyWebAuthnOptions
     /// <summary>Gets or sets the server-side ceremony lifetime in minutes.</summary>
     public int CeremonyLifetimeMinutes { get; set; } = 5;
 
+    /// <summary>Gets or sets the maximum outstanding ceremonies for one service/application boundary.</summary>
+    public int MaxOutstandingCeremoniesPerApplication { get; set; } = 512;
+
     /// <summary>Gets or sets trusted application, service, and principal-audience bindings.</summary>
     public Dictionary<string, PasskeyApplicationBinding> Bindings { get; set; } = [];
 }

--- a/Maliev.AuthService.Infrastructure/Security/PasskeyWebAuthnOptions.cs
+++ b/Maliev.AuthService.Infrastructure/Security/PasskeyWebAuthnOptions.cs
@@ -1,0 +1,28 @@
+namespace Maliev.AuthService.Infrastructure.Security;
+
+/// <summary>
+/// Configures the MALIEV WebAuthn relying-party policy.
+/// </summary>
+public sealed class PasskeyWebAuthnOptions
+{
+    /// <summary>Gets or sets whether passkey authentication is available.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Gets or sets the WebAuthn relying-party identifier.</summary>
+    public string RpId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the human-readable relying-party name.</summary>
+    public string RpName { get; set; } = "MALIEV";
+
+    /// <summary>Gets or sets the exact browser origins allowed to authenticate.</summary>
+    public IReadOnlyList<string> AllowedOrigins { get; set; } = [];
+
+    /// <summary>Gets or sets the browser ceremony timeout in milliseconds.</summary>
+    public int TimeoutMilliseconds { get; set; } = 300_000;
+
+    /// <summary>Gets or sets the number of random bytes in each challenge.</summary>
+    public int ChallengeSize { get; set; } = 32;
+
+    /// <summary>Gets or sets the server-side ceremony lifetime in minutes.</summary>
+    public int CeremonyLifetimeMinutes { get; set; } = 5;
+}

--- a/Maliev.AuthService.Infrastructure/Security/PasskeyWebAuthnOptions.cs
+++ b/Maliev.AuthService.Infrastructure/Security/PasskeyWebAuthnOptions.cs
@@ -1,3 +1,5 @@
+using Maliev.AuthService.Domain.Entities;
+
 namespace Maliev.AuthService.Infrastructure.Security;
 
 /// <summary>
@@ -25,4 +27,19 @@ public sealed class PasskeyWebAuthnOptions
 
     /// <summary>Gets or sets the server-side ceremony lifetime in minutes.</summary>
     public int CeremonyLifetimeMinutes { get; set; } = 5;
+
+    /// <summary>Gets or sets trusted application, service, and principal-audience bindings.</summary>
+    public Dictionary<string, PasskeyApplicationBinding> Bindings { get; set; } = [];
+}
+
+/// <summary>
+/// Binds one browser application to its trusted BFF and permitted principal audience.
+/// </summary>
+public sealed class PasskeyApplicationBinding
+{
+    /// <summary>Gets or sets the authenticated service name permitted to exchange assertions.</summary>
+    public string ServiceName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the principal type permitted to authenticate in the application.</summary>
+    public UserType PrincipalType { get; set; }
 }

--- a/Maliev.AuthService.Infrastructure/Services/PasskeyService.cs
+++ b/Maliev.AuthService.Infrastructure/Services/PasskeyService.cs
@@ -52,13 +52,24 @@ public sealed class PasskeyService(
             UserVerification = UserVerificationRequirement.Required,
             Extensions = null
         });
-        var issued = await ceremonyStore.IssueAsync(
-            serviceName,
-            application,
-            expectedUserType,
-            assertionOptions.ToJson(),
-            assertionOptions.Challenge,
-            ct);
+        PasskeyCeremonyIssue issued;
+        try
+        {
+            issued = await ceremonyStore.IssueAsync(
+                serviceName,
+                application,
+                expectedUserType,
+                assertionOptions.ToJson(),
+                assertionOptions.Challenge,
+                ct);
+        }
+        catch (PasskeyCeremonyCapacityExceededException)
+        {
+            logger.LogWarning(
+                "Rejected passkey ceremony because the outstanding quota was reached for application {Application}",
+                application);
+            return null;
+        }
 
         logger.LogInformation(
             "Issued passkey assertion ceremony for application {Application}",

--- a/Maliev.AuthService.Infrastructure/Services/PasskeyService.cs
+++ b/Maliev.AuthService.Infrastructure/Services/PasskeyService.cs
@@ -1,356 +1,287 @@
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
+using Fido2NetLib;
+using Fido2NetLib.Objects;
 using Maliev.AuthService.Application.DTOs.Request;
 using Maliev.AuthService.Application.DTOs.Response;
 using Maliev.AuthService.Application.Interfaces;
 using Maliev.AuthService.Domain.Entities;
 using Maliev.AuthService.Infrastructure.DbContexts;
-using Maliev.MessagingContracts;
-using Maliev.MessagingContracts.Contracts.Auth;
-using MassTransit;
+using Maliev.AuthService.Infrastructure.Security;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Maliev.AuthService.Infrastructure.Services;
 
 /// <summary>
-/// Implements WebAuthn passkey registration, authentication, and credential management.
+/// Orchestrates caller-bound, single-use WebAuthn passkey authentication.
 /// </summary>
-public class PasskeyService : IPasskeyService
+public sealed class PasskeyService(
+    AuthDbContext dbContext,
+    IPasskeyCeremonyStore ceremonyStore,
+    IPasskeyAssertionVerifier assertionVerifier,
+    IFido2 fido2,
+    IOptions<PasskeyWebAuthnOptions> options,
+    TimeProvider timeProvider,
+    ILogger<PasskeyService> logger) : IPasskeyService
 {
-    private const int MaxPasskeysPerPrincipal = 10;
-    private const int ChallengeTtlMinutes = 5;
-    private const string ChallengeKeyPrefix = "passkey:challenge:";
+    private const int VerifiedRegistrationVersion = 1;
+    private readonly PasskeyWebAuthnOptions _options = options.Value;
 
-    private readonly AuthDbContext _dbContext;
-    private readonly IDistributedCache _cache;
-    private readonly IPublishEndpoint _publishEndpoint;
-    private readonly IConfiguration _configuration;
-    private readonly ILogger<PasskeyService> _logger;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PasskeyService"/> class.
-    /// </summary>
-    /// <param name="dbContext">The database context.</param>
-    /// <param name="cache">The distributed cache for challenge storage.</param>
-    /// <param name="publishEndpoint">The publish endpoint for events.</param>
-    /// <param name="configuration">The application configuration.</param>
-    /// <param name="logger">The logger instance.</param>
-    public PasskeyService(
-        AuthDbContext dbContext,
-        IDistributedCache cache,
-        IPublishEndpoint publishEndpoint,
-        IConfiguration configuration,
-        ILogger<PasskeyService> logger)
+    /// <inheritdoc />
+    public async Task<PasskeyAuthBeginResponse?> BeginAuthenticationAsync(
+        PasskeyAuthBeginRequest request,
+        string serviceName,
+        CancellationToken ct)
     {
-        _dbContext = dbContext;
-        _cache = cache;
-        _publishEndpoint = publishEndpoint;
-        _configuration = configuration;
-        _logger = logger;
-    }
-
-    /// <inheritdoc/>
-    public async Task<PasskeyRegistrationBeginResponse> BeginRegistrationAsync(Guid principalId, CancellationToken ct)
-    {
-        var principal = await _dbContext.UserPrincipals
-            .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.Id == principalId, ct);
-
-        if (principal == null)
+        if (!_options.Enabled ||
+            request.PrincipalId.HasValue ||
+            string.IsNullOrWhiteSpace(request.Application) ||
+            string.IsNullOrWhiteSpace(serviceName) ||
+            !TryResolveBinding(
+                request.Application,
+                serviceName,
+                out var application,
+                out var expectedUserType))
         {
-            throw new InvalidOperationException($"Principal {principalId} not found");
+            return null;
         }
 
-        var challenge = RandomNumberGenerator.GetBytes(32);
-        var challengeB64 = Base64UrlEncode(challenge);
-
-        var cacheKey = $"{ChallengeKeyPrefix}{principalId}";
-        var cacheOptions = new DistributedCacheEntryOptions
+        var assertionOptions = fido2.GetAssertionOptions(new GetAssertionOptionsParams
         {
-            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(ChallengeTtlMinutes)
-        };
-        await _cache.SetStringAsync(cacheKey, challengeB64, cacheOptions, ct);
-
-        _logger.LogInformation("Passkey registration challenge created for principal {PrincipalId}", principalId);
-
-        var rpId = _configuration["Passkey:RpId"] ?? "localhost";
-        var rpName = _configuration["Passkey:RpName"] ?? "MALIEV";
-        var userIdBytes = Encoding.UTF8.GetBytes(principalId.ToString());
-        var userIdB64 = Base64UrlEncode(userIdBytes);
-
-        var pubKeyCredParams = JsonSerializer.SerializeToElement(new[]
-        {
-            new { type = "public-key", alg = -7 },
-            new { type = "public-key", alg = -257 }
+            AllowedCredentials = [],
+            UserVerification = UserVerificationRequirement.Required,
+            Extensions = null
         });
+        var issued = await ceremonyStore.IssueAsync(
+            serviceName,
+            application,
+            expectedUserType,
+            assertionOptions.ToJson(),
+            assertionOptions.Challenge,
+            ct);
 
-        var authenticatorSelection = JsonSerializer.SerializeToElement(new
-        {
-            authenticatorAttachment = "platform",
-            residentKey = "preferred",
-            userVerification = "preferred"
-        });
-
-        var attestation = JsonSerializer.SerializeToElement("none");
-
-        return new PasskeyRegistrationBeginResponse(
-            RpId: rpId,
-            RpName: rpName,
-            UserId: userIdB64,
-            UserName: principal.Email,
-            UserDisplayName: $"{principal.FirstName} {principal.LastName}",
-            Challenge: JsonSerializer.SerializeToElement(challengeB64),
-            PubKeyCredParams: pubKeyCredParams,
-            AuthenticatorSelection: authenticatorSelection,
-            Attestation: attestation,
-            Extensions: null);
-    }
-
-    /// <inheritdoc/>
-    public async Task<PasskeyRegistrationCompleteResponse> CompleteRegistrationAsync(PasskeyRegistrationCompleteRequest request, CancellationToken ct)
-    {
-        var cacheKey = $"{ChallengeKeyPrefix}{request.PrincipalId}";
-        var cachedChallenge = await _cache.GetStringAsync(cacheKey, ct);
-
-        if (string.IsNullOrEmpty(cachedChallenge))
-        {
-            _logger.LogWarning("No active challenge found for principal {PrincipalId}", request.PrincipalId);
-            return new PasskeyRegistrationCompleteResponse(false, "Challenge expired or not found");
-        }
-
-        var credentialExists = await _dbContext.PasskeyCredentials
-            .AnyAsync(c => c.CredentialId == request.CredentialId, ct);
-
-        if (credentialExists)
-        {
-            _logger.LogWarning("Duplicate credential ID {CredentialId}", request.CredentialId);
-            return new PasskeyRegistrationCompleteResponse(false, "Credential already registered");
-        }
-
-        var credentialCount = await _dbContext.PasskeyCredentials
-            .CountAsync(c => c.PrincipalId == request.PrincipalId, ct);
-
-        if (credentialCount >= MaxPasskeysPerPrincipal)
-        {
-            _logger.LogWarning("Max passkeys reached for principal {PrincipalId}", request.PrincipalId);
-            return new PasskeyRegistrationCompleteResponse(false, $"Maximum of {MaxPasskeysPerPrincipal} passkeys reached");
-        }
-
-        var credential = new PasskeyCredential
-        {
-            Id = Guid.NewGuid(),
-            PrincipalId = request.PrincipalId,
-            CredentialId = request.CredentialId,
-            PublicKey = request.PublicKey,
-            DeviceName = request.DeviceName,
-            Aaguid = request.Aaguid,
-            SignCount = 0,
-            CreatedAtUtc = DateTime.UtcNow,
-            LastUsedAtUtc = null
-        };
-
-        _dbContext.PasskeyCredentials.Add(credential);
-        await _dbContext.SaveChangesAsync(ct);
-
-        await _cache.RemoveAsync(cacheKey, ct);
-
-        _logger.LogInformation("Passkey credential {CredentialId} registered for principal {PrincipalId}", request.CredentialId, request.PrincipalId);
-
-        await _publishEndpoint.Publish(new PasskeyRegisteredEvent(
-            MessageId: Guid.NewGuid(),
-            MessageName: "PasskeyRegisteredEvent",
-            MessageType: MessageType.Event,
-            MessageVersion: "1.0.0",
-            PublishedBy: "AuthService",
-            ConsumedBy: new[] { "NotificationService" },
-            CorrelationId: Guid.NewGuid(),
-            CausationId: null,
-            OccurredAtUtc: DateTimeOffset.UtcNow,
-            IsPublic: false,
-            Payload: new PasskeyRegisteredEventPayload(
-                PrincipalId: request.PrincipalId,
-                CredentialId: request.CredentialId,
-                DeviceName: request.DeviceName,
-                RegisteredAt: DateTimeOffset.UtcNow
-            )
-        ), ct);
-
-        return new PasskeyRegistrationCompleteResponse(true, null);
-    }
-
-    /// <inheritdoc/>
-    public async Task<PasskeyAuthBeginResponse> BeginAuthenticationAsync(Guid? principalId, CancellationToken ct)
-    {
-        var challenge = RandomNumberGenerator.GetBytes(32);
-        var challengeB64 = Base64UrlEncode(challenge);
-
-        var cacheKey = principalId.HasValue
-            ? $"{ChallengeKeyPrefix}{principalId.Value}"
-            : $"{ChallengeKeyPrefix}anonymous:{Guid.NewGuid()}";
-        var cacheOptions = new DistributedCacheEntryOptions
-        {
-            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(ChallengeTtlMinutes)
-        };
-        await _cache.SetStringAsync(cacheKey, challengeB64, cacheOptions, ct);
-
-        _logger.LogInformation("Passkey authentication challenge created for principal {PrincipalId}", principalId);
-
-        var rpId = _configuration["Passkey:RpId"] ?? "localhost";
-
-        if (principalId.HasValue)
-        {
-            var credentials = await _dbContext.PasskeyCredentials
-                .AsNoTracking()
-                .Where(c => c.PrincipalId == principalId.Value)
-                .Select(c => new { c.CredentialId })
-                .ToListAsync(ct);
-
-            var allowCredentials = credentials.Select(c => new
-            {
-                type = "public-key",
-                id = c.CredentialId
-            }).ToArray();
-
-            var allowCredentialsElement = JsonSerializer.SerializeToElement(allowCredentials);
-
-            return new PasskeyAuthBeginResponse(
-                RpId: rpId,
-                Challenge: JsonSerializer.SerializeToElement(challengeB64),
-                AllowCredentials: allowCredentialsElement,
-                UserVerification: "preferred");
-        }
-
-        var emptyAllowCredentials = JsonSerializer.SerializeToElement(Array.Empty<object>());
-
+        logger.LogInformation(
+            "Issued passkey assertion ceremony for application {Application}",
+            application);
         return new PasskeyAuthBeginResponse(
-            RpId: rpId,
-            Challenge: JsonSerializer.SerializeToElement(challengeB64),
-            AllowCredentials: emptyAllowCredentials,
-            UserVerification: "required");
+            issued.FlowId,
+            issued.ExpiresAtUtc,
+            assertionOptions.RpId ?? _options.RpId,
+            ToBase64Url(assertionOptions.Challenge),
+            [],
+            "required",
+            assertionOptions.Timeout);
     }
 
-    /// <inheritdoc/>
-    public async Task<PasskeyAuthCompleteResponse> CompleteAuthenticationAsync(PasskeyAuthCompleteRequest request, CancellationToken ct)
+    /// <inheritdoc />
+    public async Task<PasskeyAuthCompleteResponse> CompleteAuthenticationAsync(
+        PasskeyAuthCompleteRequest request,
+        string serviceName,
+        CancellationToken ct)
     {
-        var credential = await _dbContext.PasskeyCredentials
-            .FirstOrDefaultAsync(c => c.CredentialId == request.CredentialId, ct);
-
-        if (credential == null)
+        if (!_options.Enabled)
         {
-            _logger.LogWarning("Credential not found: {CredentialId}", request.CredentialId);
-            return new PasskeyAuthCompleteResponse(false, "Credential not found", null, null);
+            return Failed("passkey_unavailable");
         }
 
-        var verified = VerifySignature(
-            request.AuthenticatorData,
-            request.ClientDataJson,
-            request.Signature,
-            credential.PublicKey);
-
-        if (!verified)
+        if (!TryResolveBinding(
+                request.Application,
+                serviceName,
+                out var application,
+                out _))
         {
-            _logger.LogWarning("Signature verification failed for credential {CredentialId}", request.CredentialId);
-            return new PasskeyAuthCompleteResponse(false, "Invalid signature", null, null);
+            return Failed("passkey_identity_invalid");
         }
 
-        credential.SignCount++;
-        credential.LastUsedAtUtc = DateTime.UtcNow;
-        await _dbContext.SaveChangesAsync(ct);
-
-        var principal = await _dbContext.UserPrincipals
-            .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.Id == credential.PrincipalId, ct);
-
-        _logger.LogInformation("Passkey authentication successful for principal {PrincipalId}", credential.PrincipalId);
-
-        return new PasskeyAuthCompleteResponse(true, null, credential.PrincipalId, principal?.Email);
-    }
-
-    /// <inheritdoc/>
-    public async Task<PasskeyListResponse> ListCredentialsAsync(Guid principalId, CancellationToken ct)
-    {
-        var credentials = await _dbContext.PasskeyCredentials
-            .AsNoTracking()
-            .Where(c => c.PrincipalId == principalId)
-            .OrderByDescending(c => c.CreatedAtUtc)
-            .Select(c => new PasskeyCredentialListItem(
-                c.Id,
-                c.DeviceName,
-                c.Aaguid,
-                c.CreatedAtUtc,
-                c.LastUsedAtUtc))
-            .ToListAsync(ct);
-
-        return new PasskeyListResponse(credentials);
-    }
-
-    /// <inheritdoc/>
-    public async Task<bool> DeleteCredentialAsync(Guid credentialId, Guid principalId, CancellationToken ct)
-    {
-        var credential = await _dbContext.PasskeyCredentials
-            .FirstOrDefaultAsync(c => c.Id == credentialId && c.PrincipalId == principalId, ct);
-
-        if (credential == null)
+        var ceremony = await ceremonyStore.ConsumeAsync(
+            request.FlowId,
+            serviceName,
+            application,
+            ct);
+        if (ceremony is null)
         {
-            _logger.LogWarning("Credential {CredentialId} not found for principal {PrincipalId}", credentialId, principalId);
+            logger.LogWarning(
+                "Rejected missing, expired, replayed, or caller-mismatched passkey ceremony for application {Application}",
+                NormalizeForLog(request.Application));
+            return Failed("passkey_identity_invalid");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.CredentialId) || request.CredentialId.Length > 1366)
+        {
+            return Failed("passkey_identity_invalid");
+        }
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            var credential = await FindVerifiedCredentialAsync(request.CredentialId, ct);
+            if (credential is null ||
+                !TryDecodeCanonicalBase64Url(credential.CredentialId, out var storedCredentialId))
+            {
+                return Failed("passkey_identity_invalid");
+            }
+
+            var principal = await dbContext.UserPrincipals
+                .AsNoTracking()
+                .Where(candidate =>
+                    candidate.Id == credential.PrincipalId &&
+                    candidate.UserType == ceremony.ExpectedUserType)
+                .Select(candidate => new { candidate.Id, candidate.Email })
+                .SingleOrDefaultAsync(ct);
+            if (principal is null)
+            {
+                return Failed("passkey_identity_invalid");
+            }
+
+            var verification = await assertionVerifier.VerifyAsync(
+                new PasskeyAssertionVerificationInput(
+                    ceremony.AssertionOptionsJson,
+                    request.CredentialId,
+                    request.AuthenticatorData,
+                    request.ClientDataJson,
+                    request.Signature,
+                    request.UserHandle,
+                    storedCredentialId,
+                    credential.PublicKeyCose!,
+                    credential.UserHandle!,
+                    checked((uint)credential.VerifiedSignCount!.Value),
+                    credential.IsBackupEligible!.Value),
+                ct);
+            if (!verification.Success)
+            {
+                logger.LogWarning(
+                    "Passkey assertion failed with category {FailureCategory}",
+                    verification.Failure);
+                return Failed("passkey_identity_invalid");
+            }
+
+            credential.VerifiedSignCount = verification.SignCount;
+            credential.IsBackedUp = verification.IsBackedUp;
+            credential.LastUsedAtUtc = timeProvider.GetUtcNow().UtcDateTime;
+            try
+            {
+                await dbContext.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (attempt == 0)
+                {
+                    dbContext.Entry(credential).State = EntityState.Detached;
+                    continue;
+                }
+
+                logger.LogWarning("Passkey assertion state update failed due to concurrent credential use");
+                return Failed("passkey_temporarily_unavailable");
+            }
+
+            logger.LogInformation("Passkey assertion completed successfully");
+            return new PasskeyAuthCompleteResponse(true, null, principal.Id, principal.Email);
+        }
+
+        logger.LogWarning("Passkey assertion state update failed due to concurrent credential use");
+        return Failed("passkey_temporarily_unavailable");
+    }
+
+    private Task<PasskeyCredential?> FindVerifiedCredentialAsync(
+        string credentialId,
+        CancellationToken cancellationToken) =>
+        dbContext.PasskeyCredentials.SingleOrDefaultAsync(
+            credential =>
+                credential.CredentialId == credentialId &&
+                credential.RegistrationVerificationVersion == VerifiedRegistrationVersion &&
+                credential.PublicKeyCose != null &&
+                credential.UserHandle != null &&
+                credential.VerifiedSignCount != null &&
+                credential.IsBackupEligible != null &&
+                credential.IsBackedUp != null,
+            cancellationToken);
+
+    private static PasskeyAuthCompleteResponse Failed(string code) =>
+        new(false, code, null, null);
+
+    private bool TryResolveBinding(
+        string? requestedApplication,
+        string? serviceName,
+        out string application,
+        out UserType expectedUserType)
+    {
+        application = NormalizeForBoundary(requestedApplication);
+        expectedUserType = default;
+        if (application.Length == 0 || string.IsNullOrWhiteSpace(serviceName))
+        {
             return false;
         }
 
-        _dbContext.PasskeyCredentials.Remove(credential);
-        await _dbContext.SaveChangesAsync(ct);
+        if (!_options.Bindings.TryGetValue(application, out var binding) ||
+            binding is null ||
+            !string.Equals(
+                binding.ServiceName,
+                serviceName.Trim(),
+                StringComparison.OrdinalIgnoreCase) ||
+            binding.PrincipalType is not (UserType.Customer or UserType.Employee))
+        {
+            return false;
+        }
 
-        _logger.LogInformation("Credential {CredentialId} deleted for principal {PrincipalId}", credentialId, principalId);
-
+        expectedUserType = binding.PrincipalType;
         return true;
     }
 
-    private static bool VerifySignature(string authenticatorDataB64, string clientDataJsonB64, string signatureB64, string publicKeyPem)
+    private static string NormalizeForLog(string? application)
     {
+        if (string.IsNullOrWhiteSpace(application))
+        {
+            return "missing";
+        }
+
+        var normalized = application.Trim().ToLowerInvariant();
+        return normalized.Length <= 64 &&
+            normalized.All(character => character is >= 'a' and <= 'z' or >= '0' and <= '9' or '-')
+            ? normalized
+            : "invalid";
+    }
+
+    private static string NormalizeForBoundary(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return normalized.Length <= 64 &&
+            normalized.All(character =>
+                character is >= 'a' and <= 'z' or >= '0' and <= '9' or '-')
+            ? normalized
+            : string.Empty;
+    }
+
+    private static bool TryDecodeCanonicalBase64Url(string value, out byte[] decoded)
+    {
+        decoded = [];
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.Length > 1366 ||
+            value.Contains('=') ||
+            value.Contains('+') ||
+            value.Contains('/'))
+        {
+            return false;
+        }
+
         try
         {
-            var authenticatorData = Base64UrlDecode(authenticatorDataB64);
-            var clientDataJson = Base64UrlDecode(clientDataJsonB64);
-            var clientDataHash = SHA256.HashData(clientDataJson);
-            var signedData = new byte[authenticatorData.Length + clientDataHash.Length];
-            Buffer.BlockCopy(authenticatorData, 0, signedData, 0, authenticatorData.Length);
-            Buffer.BlockCopy(clientDataHash, 0, signedData, authenticatorData.Length, clientDataHash.Length);
-            var signature = Base64UrlDecode(signatureB64);
-
-            using var ecdsa = ECDsa.Create();
-            ecdsa.ImportFromPem(publicKeyPem);
-            return ecdsa.VerifyData(signedData, signature, HashAlgorithmName.SHA256);
+            var padded = value.Replace('-', '+').Replace('_', '/');
+            padded += new string('=', (4 - padded.Length % 4) % 4);
+            decoded = Convert.FromBase64String(padded);
+            return decoded is { Length: >= 1 and <= 1024 } &&
+                string.Equals(ToBase64Url(decoded), value, StringComparison.Ordinal);
         }
-        catch
+        catch (FormatException)
         {
+            decoded = [];
             return false;
         }
     }
 
-    private static string Base64UrlEncode(byte[] data)
-    {
-        return Convert.ToBase64String(data)
-            .Replace('+', '-')
-            .Replace('/', '_')
-            .TrimEnd('=');
-    }
-
-    private static byte[] Base64UrlDecode(string base64Url)
-    {
-        var padded = base64Url.Replace('-', '+').Replace('_', '/');
-        switch (padded.Length % 4)
-        {
-            case 2:
-                padded += "==";
-                break;
-            case 3:
-                padded += "=";
-                break;
-        }
-
-        return Convert.FromBase64String(padded);
-    }
+    private static string ToBase64Url(byte[] value) =>
+        Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
 }

--- a/Maliev.AuthService.Tests/Contract/PasskeyAuthenticationContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/PasskeyAuthenticationContractTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -55,7 +56,10 @@ public sealed class PasskeyAuthenticationContractTests : IClassFixture<TestWebAp
 
         using var response = await client.PostAsJsonAsync(BeginPath, new { application = "web" });
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseBody = await response.Content.ReadAsStringAsync();
+        Assert.True(
+            response.StatusCode == HttpStatusCode.OK,
+            $"Expected 200 OK but received {(int)response.StatusCode}: {responseBody}");
         var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal(43, payload.GetProperty("flow_id").GetString()?.Length);
         Assert.True(payload.GetProperty("expires_at_utc").GetDateTime() > DateTime.UtcNow);
@@ -67,6 +71,22 @@ public sealed class PasskeyAuthenticationContractTests : IClassFixture<TestWebAp
         Assert.Equal((ulong)300_000, payload.GetProperty("timeout").GetUInt64());
         Assert.False(payload.TryGetProperty("principal_id", out _));
         Assert.False(payload.TryGetProperty("flowId", out _));
+    }
+
+    /// <summary>Verifies an enabled host rejects an unbounded or disabled outstanding-ceremony quota.</summary>
+    [Fact]
+    public void PasskeyAuthentication_ZeroOutstandingQuota_RejectsHostStartup()
+    {
+        using var invalidFactory = _factory.WithWebHostBuilder(builder =>
+            builder.ConfigureAppConfiguration((_, configuration) =>
+                configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Passkey:MaxOutstandingCeremoniesPerApplication"] = "0"
+                })));
+
+        var exception = Assert.Throws<OptionsValidationException>(() => invalidFactory.CreateClient());
+
+        Assert.Contains("bounded ceremony settings", exception.Message, StringComparison.Ordinal);
     }
 
     /// <summary>Verifies application/caller mismatches fail before a ceremony is issued.</summary>

--- a/Maliev.AuthService.Tests/Contract/PasskeyAuthenticationContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/PasskeyAuthenticationContractTests.cs
@@ -1,0 +1,224 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Maliev.AuthService.Api.Authorization;
+using Maliev.AuthService.Application.DTOs.Response;
+using Maliev.AuthService.Infrastructure.DbContexts;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Contract;
+
+/// <summary>
+/// HTTP contract tests for the service-authenticated, snake-case passkey ceremony boundary.
+/// </summary>
+public sealed class PasskeyAuthenticationContractTests : IClassFixture<TestWebApplicationFactory>
+{
+    private const string BeginPath = "/auth/v2/passkey/auth/begin";
+    private const string CompletePath = "/auth/v2/passkey/auth/complete";
+    private const string LegacyBeginPath = "/auth/v1/passkey/auth/begin";
+    private const string LegacyCompletePath = "/auth/v1/passkey/auth/complete";
+    private readonly TestWebApplicationFactory _rootFactory;
+    private readonly WebApplicationFactory<Program> _factory;
+
+    /// <summary>Initializes the contract host with passkey authentication enabled for tests.</summary>
+    public PasskeyAuthenticationContractTests(TestWebApplicationFactory factory)
+    {
+        _rootFactory = factory;
+        _factory = factory.WithWebHostBuilder(builder =>
+            builder.ConfigureAppConfiguration((_, configuration) =>
+                configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Passkey:Enabled"] = "true",
+                    ["Passkey:RpId"] = "maliev.test",
+                    ["Passkey:RpName"] = "MALIEV Test",
+                    ["Passkey:AllowedOrigins:0"] = "https://app.maliev.test",
+                    ["Passkey:AllowedOrigins:1"] = "https://www.maliev.test",
+                    ["Passkey:AllowedOrigins:2"] = "https://make.maliev.test",
+                    ["Passkey:Bindings:web:ServiceName"] = "WebBff",
+                    ["Passkey:Bindings:web:PrincipalType"] = "Customer"
+                })));
+    }
+
+    /// <summary>Verifies the trusted Web BFF receives an additive snake-case, discoverable flow.</summary>
+    [Fact]
+    public async Task BeginPasskeyAuthentication_WebBff_ReturnsSnakeCaseOneTimeOptions()
+    {
+        using var client = CreateServiceClient("WebBff");
+
+        using var response = await client.PostAsJsonAsync(BeginPath, new { application = "web" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(43, payload.GetProperty("flow_id").GetString()?.Length);
+        Assert.True(payload.GetProperty("expires_at_utc").GetDateTime() > DateTime.UtcNow);
+        Assert.Equal("maliev.test", payload.GetProperty("rp_id").GetString());
+        Assert.True(payload.GetProperty("challenge").GetString()?.Length >= 43);
+        Assert.Equal(JsonValueKind.Array, payload.GetProperty("allow_credentials").ValueKind);
+        Assert.Equal(0, payload.GetProperty("allow_credentials").GetArrayLength());
+        Assert.Equal("required", payload.GetProperty("user_verification").GetString());
+        Assert.Equal((ulong)300_000, payload.GetProperty("timeout").GetUInt64());
+        Assert.False(payload.TryGetProperty("principal_id", out _));
+        Assert.False(payload.TryGetProperty("flowId", out _));
+    }
+
+    /// <summary>Verifies application/caller mismatches fail before a ceremony is issued.</summary>
+    [Theory]
+    [InlineData("QuoteEngineBff", "web")]
+    [InlineData("WebBff", "quote-engine")]
+    public async Task BeginPasskeyAuthentication_UnboundServiceApplication_IsForbidden(
+        string serviceName,
+        string application)
+    {
+        using var client = CreateServiceClient(serviceName);
+
+        using var response = await client.PostAsJsonAsync(BeginPath, new { application });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    /// <summary>Verifies anonymous callers cannot start a passkey ceremony.</summary>
+    [Fact]
+    public async Task BeginPasskeyAuthentication_AnonymousCaller_IsUnauthorized()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.PostAsJsonAsync(BeginPath, new { application = "web" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    /// <summary>Verifies service identity without the exchange permission cannot start a ceremony.</summary>
+    [Fact]
+    public async Task BeginPasskeyAuthentication_ServiceWithoutExchangePermission_IsForbidden()
+    {
+        using var client = CreateServiceClient("WebBff", includeExchangePermission: false);
+
+        using var response = await client.PostAsJsonAsync(BeginPath, new { application = "web" });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    /// <summary>Verifies v1 routes remain present but cannot execute the retired identity contract.</summary>
+    [Theory]
+    [InlineData(LegacyBeginPath)]
+    [InlineData(LegacyCompletePath)]
+    public async Task LegacyPasskeyAuthenticationRoute_IsContained(string path)
+    {
+        using var client = CreateServiceClient("WebBff");
+
+        using var response = await client.PostAsJsonAsync(path, new
+        {
+            principal_id = Guid.NewGuid(),
+            email = "forged@example.test"
+        });
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        Assert.Equal("passkey_authentication_unavailable", error?.Error);
+    }
+
+    /// <summary>Verifies caller-authored principal scoping is rejected.</summary>
+    [Fact]
+    public async Task BeginPasskeyAuthentication_PrincipalId_IsRejected()
+    {
+        using var client = CreateServiceClient("WebBff");
+
+        using var response = await client.PostAsJsonAsync(BeginPath, new
+        {
+            application = "web",
+            principal_id = Guid.NewGuid()
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        Assert.Equal("passkey_flow_invalid", error?.Error);
+    }
+
+    /// <summary>Verifies a missing/replayed flow returns one generic error without identity data.</summary>
+    [Fact]
+    public async Task CompletePasskeyAuthentication_UnknownFlow_ReturnsGenericUnauthorized()
+    {
+        using var client = CreateServiceClient("WebBff");
+
+        using var response = await client.PostAsJsonAsync(CompletePath, new
+        {
+            application = "web",
+            flow_id = new string('A', 43),
+            credential_id = "AQ",
+            authenticator_data = new string('A', 50),
+            client_data_json = "e30",
+            signature = "AQ",
+            user_handle = "AQ"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("authentication_failed", payload.GetProperty("error").GetString());
+        Assert.False(payload.TryGetProperty("principal_id", out _));
+        Assert.False(payload.TryGetProperty("email", out _));
+    }
+
+    /// <summary>Verifies assertion fields are bounded before ceremony or credential processing.</summary>
+    [Fact]
+    public async Task CompletePasskeyAuthentication_OversizedClientData_IsRejectedByContract()
+    {
+        using var client = CreateServiceClient("WebBff");
+        using var beginResponse = await client.PostAsJsonAsync(
+            BeginPath,
+            new { application = "web" });
+        beginResponse.EnsureSuccessStatusCode();
+        var begin = await beginResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var flowId = Assert.IsType<string>(begin.GetProperty("flow_id").GetString());
+
+        using var response = await client.PostAsJsonAsync(CompletePath, new
+        {
+            application = "web",
+            flow_id = flowId,
+            credential_id = "AQ",
+            authenticator_data = new string('A', 50),
+            client_data_json = new string('A', 10_925),
+            signature = "AQ",
+            user_handle = "AQ"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var flowHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(flowId)));
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        Assert.True(await dbContext.PasskeyAssertionCeremonies
+            .AsNoTracking()
+            .AnyAsync(candidate => candidate.FlowIdHash == flowHash));
+    }
+
+    private HttpClient CreateServiceClient(
+        string serviceName,
+        bool includeExchangePermission = true)
+    {
+        var claims = new Dictionary<string, string>
+        {
+            ["user_type"] = "service",
+            ["service_name"] = serviceName
+        };
+        if (includeExchangePermission)
+        {
+            claims["permission"] = AuthPermissions.ExchangeIdentities;
+        }
+
+        var token = _rootFactory.CreateTestJwtToken(
+            Guid.NewGuid().ToString(),
+            ["service"],
+            claims);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Add("X-Test-Client-IP", "127.0.0.1");
+        return client;
+    }
+}

--- a/Maliev.AuthService.Tests/Integration/PasskeyAuthenticationServiceTests.cs
+++ b/Maliev.AuthService.Tests/Integration/PasskeyAuthenticationServiceTests.cs
@@ -1,0 +1,411 @@
+using Fido2NetLib;
+using Fido2NetLib.Objects;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Domain.Entities;
+using Maliev.AuthService.Infrastructure.Security;
+using Maliev.AuthService.Infrastructure.Services;
+using Maliev.AuthService.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL integration tests for passkey authentication orchestration and credential quarantine.
+/// </summary>
+public sealed class PasskeyAuthenticationServiceTests(
+    TestDatabaseFixture fixture) : IClassFixture<TestDatabaseFixture>, IAsyncLifetime
+{
+    private const string ServiceName = "WebBff";
+    private const string Application = "web";
+    private const string RpId = "maliev.test";
+    private const string Origin = "https://app.maliev.test";
+    private readonly ManualTimeProvider _timeProvider = new(
+        new DateTimeOffset(2026, 7, 11, 10, 0, 0, TimeSpan.Zero));
+
+    /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        await fixture.InitializeAsync();
+        await using var dbContext = fixture.CreateDbContext();
+        await dbContext.PasskeyAssertionCeremonies.ExecuteDeleteAsync();
+        await dbContext.PasskeyCredentials.ExecuteDeleteAsync();
+        await dbContext.UserPrincipals.ExecuteDeleteAsync();
+    }
+
+    /// <inheritdoc />
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    /// <summary>Verifies a verified credential can authenticate once and commits authenticator state first.</summary>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_VerifiedCredential_ReturnsCanonicalPrincipalAndRejectsReplay()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var seeded = await SeedVerifiedCredentialAsync(dbContext);
+        var verifier = SuccessfulVerifier(signCount: 9, isBackedUp: true);
+        var service = CreateService(dbContext, verifier.Object);
+        var begin = await service.BeginAuthenticationAsync(
+            new PasskeyAuthBeginRequest { Application = Application },
+            ServiceName,
+            CancellationToken.None);
+        Assert.NotNull(begin);
+
+        var request = CreateCompleteRequest(
+            begin.FlowId,
+            seeded.CredentialId,
+            ToBase64Url(seeded.UserHandle));
+        var first = await service.CompleteAuthenticationAsync(
+            request,
+            ServiceName,
+            CancellationToken.None);
+        var replay = await service.CompleteAuthenticationAsync(
+            request,
+            ServiceName,
+            CancellationToken.None);
+
+        Assert.True(first.Success);
+        Assert.Equal(seeded.PrincipalId, first.PrincipalId);
+        Assert.Equal("verified@example.test", first.Email);
+        Assert.False(replay.Success);
+        var verificationInput = Assert.IsType<PasskeyAssertionVerificationInput>(
+            Assert.Single(verifier.Invocations).Arguments[0]);
+        var assertionOptions = AssertionOptions.FromJson(verificationInput.AssertionOptionsJson);
+        Assert.Equal(begin.Challenge, ToBase64Url(assertionOptions.Challenge));
+        Assert.Equal(request.CredentialId, verificationInput.CredentialId);
+        Assert.Equal(request.AuthenticatorData, verificationInput.AuthenticatorData);
+        Assert.Equal(request.ClientDataJson, verificationInput.ClientDataJson);
+        Assert.Equal(request.Signature, verificationInput.Signature);
+        Assert.Equal(request.UserHandle, verificationInput.UserHandle);
+        Assert.Equal(FromBase64Url(seeded.CredentialId), verificationInput.StoredCredentialId);
+        Assert.Equal(seeded.PublicKeyCose, verificationInput.StoredPublicKeyCose);
+        Assert.Equal(seeded.UserHandle, verificationInput.StoredUserHandle);
+        Assert.Equal((uint)1, verificationInput.StoredSignCount);
+        Assert.False(verificationInput.StoredBackupEligible);
+        dbContext.ChangeTracker.Clear();
+        var stored = await dbContext.PasskeyCredentials.AsNoTracking().SingleAsync();
+        Assert.Equal(9, stored.VerifiedSignCount);
+        Assert.True(stored.IsBackedUp);
+        Assert.Equal(_timeProvider.GetUtcNow().UtcDateTime, stored.LastUsedAtUtc);
+    }
+
+    /// <summary>Verifies legacy browser-authored credentials never reach cryptographic verification.</summary>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_LegacyCredential_IsQuarantined()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var seeded = await SeedVerifiedCredentialAsync(dbContext, verificationVersion: 0);
+        var verifier = SuccessfulVerifier(2, false);
+        var service = CreateService(dbContext, verifier.Object);
+        var begin = await service.BeginAuthenticationAsync(
+            new PasskeyAuthBeginRequest { Application = Application },
+            ServiceName,
+            CancellationToken.None);
+
+        var result = await service.CompleteAuthenticationAsync(
+            CreateCompleteRequest(
+                begin!.FlowId,
+                seeded.CredentialId,
+                ToBase64Url(seeded.UserHandle)),
+            ServiceName,
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        verifier.VerifyNoOtherCalls();
+    }
+
+    /// <summary>Verifies customer applications cannot authenticate an employee credential.</summary>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_EmployeeCredentialForCustomerApplication_IsRejected()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var seeded = await SeedVerifiedCredentialAsync(dbContext, userType: UserType.Employee);
+        var verifier = SuccessfulVerifier(2, false);
+        var service = CreateService(dbContext, verifier.Object);
+        var begin = await service.BeginAuthenticationAsync(
+            new PasskeyAuthBeginRequest { Application = Application },
+            ServiceName,
+            CancellationToken.None);
+
+        var result = await service.CompleteAuthenticationAsync(
+            CreateCompleteRequest(
+                begin!.FlowId,
+                seeded.CredentialId,
+                ToBase64Url(seeded.UserHandle)),
+            ServiceName,
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Null(result.PrincipalId);
+        Assert.Null(result.Email);
+        verifier.VerifyNoOtherCalls();
+        dbContext.ChangeTracker.Clear();
+        var stored = await dbContext.PasskeyCredentials.AsNoTracking().SingleAsync();
+        Assert.Equal(1, stored.VerifiedSignCount);
+        Assert.Null(stored.LastUsedAtUtc);
+    }
+
+    /// <summary>Verifies the service caller and application audience are enforced without burning the flow.</summary>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_WrongCallerBoundary_DoesNotConsumeCeremony()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var seeded = await SeedVerifiedCredentialAsync(dbContext);
+        var verifier = SuccessfulVerifier(2, false);
+        var service = CreateService(dbContext, verifier.Object);
+        var begin = await service.BeginAuthenticationAsync(
+            new PasskeyAuthBeginRequest { Application = Application },
+            ServiceName,
+            CancellationToken.None);
+        var request = CreateCompleteRequest(
+            begin!.FlowId,
+            seeded.CredentialId,
+            ToBase64Url(seeded.UserHandle));
+
+        var wrongCaller = await service.CompleteAuthenticationAsync(
+            request,
+            "QuoteEngineBff",
+            CancellationToken.None);
+        var correctCaller = await service.CompleteAuthenticationAsync(
+            request,
+            ServiceName,
+            CancellationToken.None);
+
+        Assert.False(wrongCaller.Success);
+        Assert.True(correctCaller.Success);
+    }
+
+    /// <summary>Verifies an expired ceremony never reaches the assertion verifier.</summary>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_ExpiredCeremony_IsRejected()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var seeded = await SeedVerifiedCredentialAsync(dbContext);
+        var verifier = SuccessfulVerifier(2, false);
+        var service = CreateService(dbContext, verifier.Object);
+        var begin = await service.BeginAuthenticationAsync(
+            new PasskeyAuthBeginRequest { Application = Application },
+            ServiceName,
+            CancellationToken.None);
+        _timeProvider.Advance(TimeSpan.FromMinutes(6));
+
+        var result = await service.CompleteAuthenticationAsync(
+            CreateCompleteRequest(
+                begin!.FlowId,
+                seeded.CredentialId,
+                ToBase64Url(seeded.UserHandle)),
+            ServiceName,
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        verifier.VerifyNoOtherCalls();
+    }
+
+    /// <summary>Verifies an invalid assertion consumes its challenge and cannot be corrected through replay.</summary>
+    [Fact]
+    public async Task CompleteAuthenticationAsync_InvalidAssertion_ConsumesCeremony()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var seeded = await SeedVerifiedCredentialAsync(dbContext);
+        var verifier = new Mock<IPasskeyAssertionVerifier>();
+        verifier.Setup(candidate => candidate.VerifyAsync(
+                It.IsAny<PasskeyAssertionVerificationInput>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PasskeyAssertionVerificationResult.Failed(
+                PasskeyAssertionFailure.VerificationFailed));
+        var service = CreateService(dbContext, verifier.Object);
+        var begin = await service.BeginAuthenticationAsync(
+            new PasskeyAuthBeginRequest { Application = Application },
+            ServiceName,
+            CancellationToken.None);
+        var request = CreateCompleteRequest(
+            begin!.FlowId,
+            seeded.CredentialId,
+            ToBase64Url(seeded.UserHandle));
+
+        var invalid = await service.CompleteAuthenticationAsync(
+            request,
+            ServiceName,
+            CancellationToken.None);
+        verifier.Reset();
+        verifier.Setup(candidate => candidate.VerifyAsync(
+                It.IsAny<PasskeyAssertionVerificationInput>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PasskeyAssertionVerificationResult(
+                true,
+                2,
+                false,
+                PasskeyAssertionFailure.None));
+        var correctedReplay = await service.CompleteAuthenticationAsync(
+            request,
+            ServiceName,
+            CancellationToken.None);
+
+        Assert.False(invalid.Success);
+        Assert.False(correctedReplay.Success);
+        verifier.VerifyNoOtherCalls();
+    }
+
+    /// <summary>Verifies disabled or user-scoped begin requests fail without storing a ceremony.</summary>
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public async Task BeginAuthenticationAsync_DisabledOrPrincipalScoped_DoesNotIssueFlow(
+        bool enabled,
+        bool principalScoped)
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var service = CreateService(
+            dbContext,
+            SuccessfulVerifier(1, false).Object,
+            enabled);
+
+        var result = await service.BeginAuthenticationAsync(
+            new PasskeyAuthBeginRequest
+            {
+                Application = Application,
+                PrincipalId = principalScoped ? Guid.NewGuid() : null
+            },
+            ServiceName,
+            CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.False(await dbContext.PasskeyAssertionCeremonies.AnyAsync());
+    }
+
+    private PasskeyService CreateService(
+        Maliev.AuthService.Infrastructure.DbContexts.AuthDbContext dbContext,
+        IPasskeyAssertionVerifier verifier,
+        bool enabled = true)
+    {
+        var options = Options.Create(new PasskeyWebAuthnOptions
+        {
+            Enabled = enabled,
+            RpId = RpId,
+            RpName = "MALIEV Test",
+            AllowedOrigins = [Origin],
+            TimeoutMilliseconds = 300_000,
+            ChallengeSize = 32,
+            CeremonyLifetimeMinutes = 5,
+            Bindings = new Dictionary<string, PasskeyApplicationBinding>
+            {
+                [Application] = new()
+                {
+                    ServiceName = ServiceName,
+                    PrincipalType = UserType.Customer
+                }
+            }
+        });
+        var fido2 = new Fido2(new Fido2Configuration
+        {
+            ServerDomain = RpId,
+            ServerName = "MALIEV Test",
+            Origins = new HashSet<string>([Origin], StringComparer.Ordinal),
+            Timeout = 300_000,
+            ChallengeSize = 32
+        });
+        return new PasskeyService(
+            dbContext,
+            new PasskeyCeremonyStore(dbContext, options, _timeProvider),
+            verifier,
+            fido2,
+            options,
+            _timeProvider,
+            NullLogger<PasskeyService>.Instance);
+    }
+
+    private async Task<(
+        Guid PrincipalId,
+        string CredentialId,
+        byte[] PublicKeyCose,
+        byte[] UserHandle)> SeedVerifiedCredentialAsync(
+        Maliev.AuthService.Infrastructure.DbContexts.AuthDbContext dbContext,
+        int verificationVersion = 1,
+        UserType userType = UserType.Customer)
+    {
+        var principalId = Guid.NewGuid();
+        var credentialId = ToBase64Url(Guid.NewGuid().ToByteArray());
+        byte[] publicKeyCose = [1, 2, 3];
+        var userHandle = Guid.NewGuid().ToByteArray();
+        dbContext.UserPrincipals.Add(new UserPrincipal
+        {
+            Id = principalId,
+            Email = "verified@example.test",
+            FirstName = "Verified",
+            LastName = "Customer",
+            UserType = userType,
+            EmailVerifiedAtUtc = _timeProvider.GetUtcNow().UtcDateTime,
+            CreatedAt = _timeProvider.GetUtcNow().UtcDateTime,
+            UpdatedAt = _timeProvider.GetUtcNow().UtcDateTime
+        });
+        dbContext.PasskeyCredentials.Add(new PasskeyCredential
+        {
+            Id = Guid.NewGuid(),
+            PrincipalId = principalId,
+            CredentialId = credentialId,
+            PublicKey = string.Empty,
+            PublicKeyCose = publicKeyCose,
+            UserHandle = userHandle,
+            DeviceName = "Verified test credential",
+            RegistrationVerificationVersion = verificationVersion,
+            VerifiedSignCount = 1,
+            IsBackupEligible = false,
+            IsBackedUp = false,
+            SignCount = 0,
+            CreatedAtUtc = _timeProvider.GetUtcNow().UtcDateTime
+        });
+        await dbContext.SaveChangesAsync();
+        return (principalId, credentialId, publicKeyCose, userHandle);
+    }
+
+    private static Mock<IPasskeyAssertionVerifier> SuccessfulVerifier(
+        uint signCount,
+        bool isBackedUp)
+    {
+        var verifier = new Mock<IPasskeyAssertionVerifier>();
+        verifier.Setup(candidate => candidate.VerifyAsync(
+                It.IsAny<PasskeyAssertionVerificationInput>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PasskeyAssertionVerificationResult(
+                true,
+                signCount,
+                isBackedUp,
+                PasskeyAssertionFailure.None));
+        return verifier;
+    }
+
+    private static PasskeyAuthCompleteRequest CreateCompleteRequest(
+        string flowId,
+        string credentialId,
+        string userHandle) => new()
+    {
+        Application = Application,
+        FlowId = flowId,
+        CredentialId = credentialId,
+        AuthenticatorData = "AQ",
+        ClientDataJson = "e30",
+        Signature = "AQ",
+        UserHandle = userHandle
+    };
+
+    private static byte[] FromBase64Url(string value)
+    {
+        var padded = value.Replace('-', '+').Replace('_', '/');
+        padded += new string('=', (4 - padded.Length % 4) % 4);
+        return Convert.FromBase64String(padded);
+    }
+
+    private static string ToBase64Url(byte[] value) =>
+        Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private sealed class ManualTimeProvider(DateTimeOffset initialUtcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = initialUtcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration) => _utcNow = _utcNow.Add(duration);
+    }
+}

--- a/Maliev.AuthService.Tests/Integration/PasskeyAuthenticationServiceTests.cs
+++ b/Maliev.AuthService.Tests/Integration/PasskeyAuthenticationServiceTests.cs
@@ -275,10 +275,36 @@ public sealed class PasskeyAuthenticationServiceTests(
         Assert.False(await dbContext.PasskeyAssertionCeremonies.AnyAsync());
     }
 
+    /// <summary>Verifies a saturated ceremony boundary fails closed without exposing an unhandled store error.</summary>
+    [Fact]
+    public async Task BeginAuthenticationAsync_CeremonyQuotaReached_ReturnsUnavailable()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var service = CreateService(
+            dbContext,
+            SuccessfulVerifier(1, false).Object,
+            maxOutstandingCeremonies: 1);
+        var request = new PasskeyAuthBeginRequest { Application = Application };
+        var first = await service.BeginAuthenticationAsync(
+            request,
+            ServiceName,
+            CancellationToken.None);
+
+        var saturated = await service.BeginAuthenticationAsync(
+            request,
+            ServiceName,
+            CancellationToken.None);
+
+        Assert.NotNull(first);
+        Assert.Null(saturated);
+        Assert.Equal(1, await dbContext.PasskeyAssertionCeremonies.CountAsync());
+    }
+
     private PasskeyService CreateService(
         Maliev.AuthService.Infrastructure.DbContexts.AuthDbContext dbContext,
         IPasskeyAssertionVerifier verifier,
-        bool enabled = true)
+        bool enabled = true,
+        int maxOutstandingCeremonies = 512)
     {
         var options = Options.Create(new PasskeyWebAuthnOptions
         {
@@ -289,6 +315,7 @@ public sealed class PasskeyAuthenticationServiceTests(
             TimeoutMilliseconds = 300_000,
             ChallengeSize = 32,
             CeremonyLifetimeMinutes = 5,
+            MaxOutstandingCeremoniesPerApplication = maxOutstandingCeremonies,
             Bindings = new Dictionary<string, PasskeyApplicationBinding>
             {
                 [Application] = new()
@@ -379,16 +406,17 @@ public sealed class PasskeyAuthenticationServiceTests(
     private static PasskeyAuthCompleteRequest CreateCompleteRequest(
         string flowId,
         string credentialId,
-        string userHandle) => new()
-    {
-        Application = Application,
-        FlowId = flowId,
-        CredentialId = credentialId,
-        AuthenticatorData = "AQ",
-        ClientDataJson = "e30",
-        Signature = "AQ",
-        UserHandle = userHandle
-    };
+        string userHandle) =>
+        new()
+        {
+            Application = Application,
+            FlowId = flowId,
+            CredentialId = credentialId,
+            AuthenticatorData = "AQ",
+            ClientDataJson = "e30",
+            Signature = "AQ",
+            UserHandle = userHandle
+        };
 
     private static byte[] FromBase64Url(string value)
     {

--- a/Maliev.AuthService.Tests/Integration/PasskeyCeremonyStoreTests.cs
+++ b/Maliev.AuthService.Tests/Integration/PasskeyCeremonyStoreTests.cs
@@ -1,0 +1,196 @@
+using Maliev.AuthService.Infrastructure.Security;
+using Maliev.AuthService.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL integration tests for expiring, caller-bound, single-use passkey ceremonies.
+/// </summary>
+public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixture>, IAsyncLifetime
+{
+    private const string ServiceName = "WebBff";
+    private const string Application = "web";
+    private readonly TestDatabaseFixture _fixture;
+    private readonly ManualTimeProvider _timeProvider = new(
+        new DateTimeOffset(2026, 7, 11, 9, 0, 0, TimeSpan.Zero));
+
+    /// <summary>Initializes the tests with the shared real-infrastructure fixture.</summary>
+    /// <param name="fixture">The PostgreSQL, Redis, and RabbitMQ test fixture.</param>
+    public PasskeyCeremonyStoreTests(TestDatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        await using var dbContext = _fixture.CreateDbContext();
+        await dbContext.PasskeyAssertionCeremonies.ExecuteDeleteAsync();
+    }
+
+    /// <inheritdoc />
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Verifies a matching ceremony can be consumed only once.</summary>
+    [Fact]
+    public async Task ConsumeAsync_MatchingCallerAndApplication_IsSingleUse()
+    {
+        await using var dbContext = _fixture.CreateDbContext();
+        var store = CreateStore(dbContext);
+        var issued = await store.IssueAsync(
+            ServiceName,
+            Application,
+            "{\"challenge\":\"server-owned\"}",
+            new byte[32],
+            CancellationToken.None);
+
+        var first = await store.ConsumeAsync(
+            issued.FlowId,
+            ServiceName,
+            Application,
+            CancellationToken.None);
+        var replay = await store.ConsumeAsync(
+            issued.FlowId,
+            ServiceName,
+            Application,
+            CancellationToken.None);
+
+        Assert.NotNull(first);
+        using var options = JsonDocument.Parse(first.AssertionOptionsJson);
+        Assert.Equal("server-owned", options.RootElement.GetProperty("challenge").GetString());
+        Assert.Null(replay);
+        Assert.Equal(0, await dbContext.PasskeyAssertionCeremonies.CountAsync());
+    }
+
+    /// <summary>Verifies the wrong service or application cannot consume another caller's flow.</summary>
+    [Theory]
+    [InlineData("QuoteEngineBff", Application)]
+    [InlineData(ServiceName, "quote-engine")]
+    public async Task ConsumeAsync_WrongCallerBoundary_DoesNotBurnCeremony(
+        string serviceName,
+        string application)
+    {
+        await using var dbContext = _fixture.CreateDbContext();
+        var store = CreateStore(dbContext);
+        var issued = await store.IssueAsync(
+            ServiceName,
+            Application,
+            "{\"challenge\":\"bound\"}",
+            Enumerable.Repeat((byte)7, 32).ToArray(),
+            CancellationToken.None);
+
+        var wrongBoundary = await store.ConsumeAsync(
+            issued.FlowId,
+            serviceName,
+            application,
+            CancellationToken.None);
+        var correctBoundary = await store.ConsumeAsync(
+            issued.FlowId,
+            ServiceName,
+            Application,
+            CancellationToken.None);
+
+        Assert.Null(wrongBoundary);
+        Assert.NotNull(correctBoundary);
+    }
+
+    /// <summary>Verifies expired ceremonies cannot be consumed.</summary>
+    [Fact]
+    public async Task ConsumeAsync_ExpiredCeremony_IsRejected()
+    {
+        await using var dbContext = _fixture.CreateDbContext();
+        var store = CreateStore(dbContext);
+        var issued = await store.IssueAsync(
+            ServiceName,
+            Application,
+            "{\"challenge\":\"expired\"}",
+            Enumerable.Repeat((byte)9, 32).ToArray(),
+            CancellationToken.None);
+        _timeProvider.Advance(TimeSpan.FromMinutes(6));
+
+        var result = await store.ConsumeAsync(
+            issued.FlowId,
+            ServiceName,
+            Application,
+            CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>Verifies the database contains only hashes of browser-visible flow and challenge values.</summary>
+    [Fact]
+    public async Task IssueAsync_PersistsOnlyFlowAndChallengeHashes()
+    {
+        await using var dbContext = _fixture.CreateDbContext();
+        var store = CreateStore(dbContext);
+        var challenge = Enumerable.Range(1, 32).Select(value => (byte)value).ToArray();
+        var issued = await store.IssueAsync(
+            ServiceName,
+            Application,
+            "{\"challenge\":\"hashed\"}",
+            challenge,
+            CancellationToken.None);
+
+        var record = await dbContext.PasskeyAssertionCeremonies.AsNoTracking().SingleAsync();
+
+        Assert.Equal(64, record.FlowIdHash.Length);
+        Assert.Equal(64, record.ChallengeHash.Length);
+        Assert.DoesNotContain(issued.FlowId, record.FlowIdHash, StringComparison.Ordinal);
+        Assert.DoesNotContain(Convert.ToBase64String(challenge), record.ChallengeHash, StringComparison.Ordinal);
+        Assert.Equal(ServiceName.ToLowerInvariant(), record.ServiceName);
+        Assert.Equal(Application, record.Application);
+    }
+
+    /// <summary>Verifies two concurrent requests produce exactly one ceremony winner.</summary>
+    [Fact]
+    public async Task ConsumeAsync_ConcurrentReplay_HasExactlyOneWinner()
+    {
+        string flowId;
+        await using (var issueContext = _fixture.CreateDbContext())
+        {
+            var issueStore = CreateStore(issueContext);
+            var issued = await issueStore.IssueAsync(
+                ServiceName,
+                Application,
+                "{\"challenge\":\"concurrent\"}",
+                Enumerable.Repeat((byte)11, 32).ToArray(),
+                CancellationToken.None);
+            flowId = issued.FlowId;
+        }
+
+        await using var firstContext = _fixture.CreateDbContext();
+        await using var secondContext = _fixture.CreateDbContext();
+        var firstStore = CreateStore(firstContext);
+        var secondStore = CreateStore(secondContext);
+
+        var results = await Task.WhenAll(
+            firstStore.ConsumeAsync(flowId, ServiceName, Application, CancellationToken.None),
+            secondStore.ConsumeAsync(flowId, ServiceName, Application, CancellationToken.None));
+
+        Assert.Single(results, result => result is not null);
+    }
+
+    private PasskeyCeremonyStore CreateStore(
+        Maliev.AuthService.Infrastructure.DbContexts.AuthDbContext dbContext) =>
+        new(
+            dbContext,
+            Options.Create(new PasskeyWebAuthnOptions { CeremonyLifetimeMinutes = 5 }),
+            _timeProvider);
+
+    private sealed class ManualTimeProvider(DateTimeOffset initialUtcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = initialUtcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration) => _utcNow = _utcNow.Add(duration);
+    }
+}

--- a/Maliev.AuthService.Tests/Integration/PasskeyCeremonyStoreTests.cs
+++ b/Maliev.AuthService.Tests/Integration/PasskeyCeremonyStoreTests.cs
@@ -156,6 +156,135 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
         Assert.Equal(UserType.Customer, record.ExpectedUserType);
     }
 
+    /// <summary>Verifies one caller/application boundary cannot exceed its outstanding ceremony quota.</summary>
+    [Fact]
+    public async Task IssueAsync_BoundaryAtOutstandingLimit_RejectsAdditionalCeremony()
+    {
+        await using var dbContext = _fixture.CreateDbContext();
+        var store = CreateStore(dbContext, maxOutstandingCeremonies: 1);
+        await store.IssueAsync(
+            ServiceName,
+            Application,
+            UserType.Customer,
+            "{\"challenge\":\"first\"}",
+            Enumerable.Repeat((byte)12, 32).ToArray(),
+            CancellationToken.None);
+
+        await Assert.ThrowsAsync<PasskeyCeremonyCapacityExceededException>(() =>
+            store.IssueAsync(
+                ServiceName,
+                Application,
+                UserType.Customer,
+                "{\"challenge\":\"second\"}",
+                Enumerable.Repeat((byte)13, 32).ToArray(),
+                CancellationToken.None));
+
+        Assert.Equal(1, await dbContext.PasskeyAssertionCeremonies.CountAsync());
+    }
+
+    /// <summary>Verifies expired ceremonies are removed before quota enforcement and release capacity.</summary>
+    [Fact]
+    public async Task IssueAsync_ExpiredCeremony_ReleasesBoundaryCapacity()
+    {
+        await using var dbContext = _fixture.CreateDbContext();
+        var store = CreateStore(dbContext, maxOutstandingCeremonies: 1);
+        var expired = await store.IssueAsync(
+            ServiceName,
+            Application,
+            UserType.Customer,
+            "{\"challenge\":\"expires\"}",
+            Enumerable.Repeat((byte)14, 32).ToArray(),
+            CancellationToken.None);
+        _timeProvider.Advance(TimeSpan.FromMinutes(6));
+
+        var replacement = await store.IssueAsync(
+            ServiceName,
+            Application,
+            UserType.Customer,
+            "{\"challenge\":\"replacement\"}",
+            Enumerable.Repeat((byte)15, 32).ToArray(),
+            CancellationToken.None);
+
+        Assert.NotEqual(expired.FlowId, replacement.FlowId);
+        Assert.Equal(1, await dbContext.PasskeyAssertionCeremonies.CountAsync());
+    }
+
+    /// <summary>Verifies one saturated application does not consume another trusted boundary's capacity.</summary>
+    [Fact]
+    public async Task IssueAsync_DifferentApplication_HasIndependentQuota()
+    {
+        await using var dbContext = _fixture.CreateDbContext();
+        var store = CreateStore(dbContext, maxOutstandingCeremonies: 1);
+        await store.IssueAsync(
+            ServiceName,
+            Application,
+            UserType.Customer,
+            "{\"challenge\":\"web\"}",
+            Enumerable.Repeat((byte)16, 32).ToArray(),
+            CancellationToken.None);
+
+        var quoteEngine = await store.IssueAsync(
+            "QuoteEngineBff",
+            "quote-engine",
+            UserType.Customer,
+            "{\"challenge\":\"quote\"}",
+            Enumerable.Repeat((byte)17, 32).ToArray(),
+            CancellationToken.None);
+
+        Assert.NotEmpty(quoteEngine.FlowId);
+        Assert.Equal(2, await dbContext.PasskeyAssertionCeremonies.CountAsync());
+    }
+
+    /// <summary>Verifies concurrent issuers cannot race past one boundary's configured quota.</summary>
+    [Fact]
+    public async Task IssueAsync_ConcurrentRequestsAtLimit_HasExactlyOneWinner()
+    {
+        const int requestCount = 12;
+        var contexts = Enumerable.Range(0, requestCount)
+            .Select(_ => _fixture.CreateDbContext())
+            .ToArray();
+        try
+        {
+            var stores = contexts
+                .Select(context => CreateStore(context, maxOutstandingCeremonies: 1))
+                .ToArray();
+            var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var attempts = stores.Select(async (store, index) =>
+            {
+                await start.Task;
+                try
+                {
+                    await store.IssueAsync(
+                        ServiceName,
+                        Application,
+                        UserType.Customer,
+                        $"{{\"challenge\":\"concurrent-{index}\"}}",
+                        Enumerable.Repeat(checked((byte)(index + 20)), 32).ToArray(),
+                        CancellationToken.None);
+                    return true;
+                }
+                catch (PasskeyCeremonyCapacityExceededException)
+                {
+                    return false;
+                }
+            }).ToArray();
+
+            start.SetResult();
+            var results = await Task.WhenAll(attempts);
+
+            Assert.Single(results, issued => issued);
+            await using var verificationContext = _fixture.CreateDbContext();
+            Assert.Equal(1, await verificationContext.PasskeyAssertionCeremonies.CountAsync());
+        }
+        finally
+        {
+            foreach (var context in contexts)
+            {
+                await context.DisposeAsync();
+            }
+        }
+    }
+
     /// <summary>Verifies two concurrent requests produce exactly one ceremony winner.</summary>
     [Fact]
     public async Task ConsumeAsync_ConcurrentReplay_HasExactlyOneWinner()
@@ -187,10 +316,15 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
     }
 
     private PasskeyCeremonyStore CreateStore(
-        Maliev.AuthService.Infrastructure.DbContexts.AuthDbContext dbContext) =>
+        Maliev.AuthService.Infrastructure.DbContexts.AuthDbContext dbContext,
+        int maxOutstandingCeremonies = 512) =>
         new(
             dbContext,
-            Options.Create(new PasskeyWebAuthnOptions { CeremonyLifetimeMinutes = 5 }),
+            Options.Create(new PasskeyWebAuthnOptions
+            {
+                CeremonyLifetimeMinutes = 5,
+                MaxOutstandingCeremoniesPerApplication = maxOutstandingCeremonies
+            }),
             _timeProvider);
 
     private sealed class ManualTimeProvider(DateTimeOffset initialUtcNow) : TimeProvider

--- a/Maliev.AuthService.Tests/Integration/PasskeyCeremonyStoreTests.cs
+++ b/Maliev.AuthService.Tests/Integration/PasskeyCeremonyStoreTests.cs
@@ -1,3 +1,4 @@
+using Maliev.AuthService.Domain.Entities;
 using Maliev.AuthService.Infrastructure.Security;
 using Maliev.AuthService.Tests.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -48,6 +49,7 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
         var issued = await store.IssueAsync(
             ServiceName,
             Application,
+            UserType.Customer,
             "{\"challenge\":\"server-owned\"}",
             new byte[32],
             CancellationToken.None);
@@ -64,6 +66,7 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
             CancellationToken.None);
 
         Assert.NotNull(first);
+        Assert.Equal(UserType.Customer, first.ExpectedUserType);
         using var options = JsonDocument.Parse(first.AssertionOptionsJson);
         Assert.Equal("server-owned", options.RootElement.GetProperty("challenge").GetString());
         Assert.Null(replay);
@@ -83,6 +86,7 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
         var issued = await store.IssueAsync(
             ServiceName,
             Application,
+            UserType.Customer,
             "{\"challenge\":\"bound\"}",
             Enumerable.Repeat((byte)7, 32).ToArray(),
             CancellationToken.None);
@@ -111,6 +115,7 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
         var issued = await store.IssueAsync(
             ServiceName,
             Application,
+            UserType.Customer,
             "{\"challenge\":\"expired\"}",
             Enumerable.Repeat((byte)9, 32).ToArray(),
             CancellationToken.None);
@@ -135,6 +140,7 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
         var issued = await store.IssueAsync(
             ServiceName,
             Application,
+            UserType.Customer,
             "{\"challenge\":\"hashed\"}",
             challenge,
             CancellationToken.None);
@@ -147,6 +153,7 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
         Assert.DoesNotContain(Convert.ToBase64String(challenge), record.ChallengeHash, StringComparison.Ordinal);
         Assert.Equal(ServiceName.ToLowerInvariant(), record.ServiceName);
         Assert.Equal(Application, record.Application);
+        Assert.Equal(UserType.Customer, record.ExpectedUserType);
     }
 
     /// <summary>Verifies two concurrent requests produce exactly one ceremony winner.</summary>
@@ -160,6 +167,7 @@ public sealed class PasskeyCeremonyStoreTests : IClassFixture<TestDatabaseFixtur
             var issued = await issueStore.IssueAsync(
                 ServiceName,
                 Application,
+                UserType.Customer,
                 "{\"challenge\":\"concurrent\"}",
                 Enumerable.Repeat((byte)11, 32).ToArray(),
                 CancellationToken.None);

--- a/Maliev.AuthService.Tests/Integration/PasskeyCredentialQuarantineTests.cs
+++ b/Maliev.AuthService.Tests/Integration/PasskeyCredentialQuarantineTests.cs
@@ -1,0 +1,93 @@
+using Maliev.AuthService.Domain.Entities;
+using Maliev.AuthService.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Integration;
+
+/// <summary>
+/// PostgreSQL tests that quarantine credentials created by the former unverified registration flow.
+/// </summary>
+public sealed class PasskeyCredentialQuarantineTests(
+    TestDatabaseFixture fixture) : IClassFixture<TestDatabaseFixture>, IAsyncLifetime
+{
+    /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        await fixture.InitializeAsync();
+        await using var dbContext = fixture.CreateDbContext();
+        await dbContext.PasskeyCredentials.ExecuteDeleteAsync();
+    }
+
+    /// <inheritdoc />
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    /// <summary>Verifies pre-hardening rows default to unverified and have no trusted key material.</summary>
+    [Fact]
+    public async Task LegacyCredentialRow_IsQuarantinedByDefault()
+    {
+        var credentialId = Guid.NewGuid().ToString("N");
+        await using var dbContext = fixture.CreateDbContext();
+        await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
+            INSERT INTO passkey_credentials
+                (id, principal_id, credential_id, public_key, device_name, sign_count, created_at_utc)
+            VALUES
+                ({Guid.NewGuid()}, {Guid.NewGuid()}, {credentialId}, {'p' + "em"}, {'l' + "egacy"}, {0}, {DateTime.UtcNow})
+            """);
+
+        var credential = await dbContext.PasskeyCredentials.AsNoTracking().SingleAsync();
+
+        Assert.Equal(0, credential.RegistrationVerificationVersion);
+        Assert.Null(credential.PublicKeyCose);
+        Assert.Null(credential.UserHandle);
+        Assert.Null(credential.VerifiedSignCount);
+        Assert.Null(credential.IsBackupEligible);
+        Assert.Null(credential.IsBackedUp);
+    }
+
+    /// <summary>Verifies verified authenticator state can represent the full unsigned WebAuthn counter range.</summary>
+    [Fact]
+    public async Task VerifiedCredential_PersistsTrustedAuthenticatorState()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        var credential = CreateVerifiedCredential(uint.MaxValue);
+        dbContext.PasskeyCredentials.Add(credential);
+
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        var stored = await dbContext.PasskeyCredentials.AsNoTracking().SingleAsync();
+
+        Assert.Equal(1, stored.RegistrationVerificationVersion);
+        Assert.Equal((long)uint.MaxValue, stored.VerifiedSignCount);
+        Assert.NotNull(stored.PublicKeyCose);
+        Assert.NotNull(stored.UserHandle);
+        Assert.False(stored.IsBackupEligible);
+        Assert.False(stored.IsBackedUp);
+    }
+
+    /// <summary>Verifies counters outside the WebAuthn uint32 range are rejected by PostgreSQL.</summary>
+    [Fact]
+    public async Task VerifiedCredential_CounterAboveUint32_IsRejected()
+    {
+        await using var dbContext = fixture.CreateDbContext();
+        dbContext.PasskeyCredentials.Add(CreateVerifiedCredential((long)uint.MaxValue + 1));
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => dbContext.SaveChangesAsync());
+    }
+
+    private static PasskeyCredential CreateVerifiedCredential(long signCount) => new()
+    {
+        Id = Guid.NewGuid(),
+        PrincipalId = Guid.NewGuid(),
+        CredentialId = Guid.NewGuid().ToString("N"),
+        PublicKey = string.Empty,
+        PublicKeyCose = [1, 2, 3],
+        UserHandle = Guid.NewGuid().ToByteArray(),
+        DeviceName = "Verified test credential",
+        RegistrationVerificationVersion = 1,
+        VerifiedSignCount = signCount,
+        IsBackupEligible = false,
+        IsBackedUp = false,
+        CreatedAtUtc = DateTime.UtcNow
+    };
+}

--- a/Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj
+++ b/Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Fido2" Version="4.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.8.1" />

--- a/Maliev.AuthService.Tests/Unit/PasskeyAssertionVerifierTests.cs
+++ b/Maliev.AuthService.Tests/Unit/PasskeyAssertionVerifierTests.cs
@@ -1,0 +1,332 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Fido2NetLib;
+using Fido2NetLib.Objects;
+using Maliev.AuthService.Infrastructure.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+/// <summary>
+/// Exercises MALIEV's policy wrapper around the standards-compliant FIDO2 assertion verifier.
+/// </summary>
+public sealed class PasskeyAssertionVerifierTests
+{
+    private const string RpId = "maliev.test";
+    private const string Origin = "https://app.maliev.test";
+
+    /// <summary>Verifies a correctly signed, user-verified assertion succeeds.</summary>
+    [Fact]
+    public async Task VerifyAsync_ValidEs256Assertion_ReturnsUpdatedAuthenticatorState()
+    {
+        using var assertion = TestAssertion.Create(signCount: 7);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal((uint)7, result.SignCount);
+        Assert.False(result.IsBackedUp);
+    }
+
+    /// <summary>Verifies origin matching is exact and rejects a URL the library would normalize.</summary>
+    [Fact]
+    public async Task VerifyAsync_OriginWithPath_IsRejectedBeforeLibraryNormalization()
+    {
+        using var assertion = TestAssertion.Create(origin: $"{Origin}/attacker-path");
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.InvalidOrigin, result.Failure);
+    }
+
+    /// <summary>Verifies cross-origin assertions are rejected even when the effective origin is allowed.</summary>
+    [Fact]
+    public async Task VerifyAsync_CrossOriginClientData_IsRejected()
+    {
+        using var assertion = TestAssertion.Create(crossOrigin: true);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.CrossOriginNotAllowed, result.Failure);
+    }
+
+    /// <summary>Verifies unsolicited authenticator flags fail closed.</summary>
+    [Theory]
+    [InlineData(0x45)] // UP | UV | AT
+    [InlineData(0x85)] // UP | UV | ED
+    [InlineData(0x07)] // UP | reserved bit | UV
+    public async Task VerifyAsync_UnsolicitedOrReservedAuthenticatorFlags_AreRejected(byte flags)
+    {
+        using var assertion = TestAssertion.Create(flags: flags);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.InvalidAuthenticatorFlags, result.Failure);
+    }
+
+    /// <summary>Verifies a synced-passkey backup eligibility bit cannot change after registration.</summary>
+    [Fact]
+    public async Task VerifyAsync_BackupEligibilityChanged_IsRejected()
+    {
+        using var assertion = TestAssertion.Create(flags: 0x0D, storedBackupEligible: false);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.BackupEligibilityChanged, result.Failure);
+    }
+
+    /// <summary>Verifies a positive stored counter cannot reset to zero.</summary>
+    [Fact]
+    public async Task VerifyAsync_PositiveStoredCounterResetToZero_IsRejected()
+    {
+        using var assertion = TestAssertion.Create(signCount: 0, storedSignCount: 6);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.InvalidSignCount, result.Failure);
+    }
+
+    /// <summary>Verifies discoverable authentication always proves the stored user handle.</summary>
+    [Fact]
+    public async Task VerifyAsync_MissingUserHandle_IsRejected()
+    {
+        using var assertion = TestAssertion.Create(includeUserHandle: false);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.InvalidUserHandle, result.Failure);
+    }
+
+    /// <summary>Verifies signed browser data must contain the issued challenge and WebAuthn get type.</summary>
+    [Theory]
+    [InlineData(true, "webauthn.get")]
+    [InlineData(false, "webauthn.create")]
+    public async Task VerifyAsync_WrongChallengeOrType_IsRejected(bool useWrongChallenge, string type)
+    {
+        using var assertion = TestAssertion.Create(useWrongChallenge: useWrongChallenge, type: type);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.InvalidClientData, result.Failure);
+    }
+
+    /// <summary>Verifies an embedded top origin is rejected because MALIEV does not allow embedded ceremonies.</summary>
+    [Fact]
+    public async Task VerifyAsync_TopOriginPresent_IsRejected()
+    {
+        using var assertion = TestAssertion.Create(topOrigin: "https://embedder.maliev.test");
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.CrossOriginNotAllowed, result.Failure);
+    }
+
+    /// <summary>Verifies missing verification or impossible backup-state flags fail closed.</summary>
+    [Theory]
+    [InlineData(0x01)] // UP only
+    [InlineData(0x15)] // UP | UV | BS without BE
+    public async Task VerifyAsync_MissingVerificationOrImpossibleBackupState_IsRejected(byte flags)
+    {
+        using var assertion = TestAssertion.Create(flags: flags);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.InvalidAuthenticatorFlags, result.Failure);
+    }
+
+    /// <summary>Verifies RP hash and signature tampering are rejected by the FIDO2 verifier.</summary>
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task VerifyAsync_RpHashOrSignatureTampering_IsRejected(bool wrongRpIdHash, bool tamperSignature)
+    {
+        using var assertion = TestAssertion.Create(
+            authenticatorRpId: wrongRpIdHash ? "attacker.test" : RpId,
+            tamperSignature: tamperSignature);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.VerificationFailed, result.Failure);
+    }
+
+    /// <summary>Verifies stored credential and user-handle ownership cannot be substituted.</summary>
+    [Theory]
+    [InlineData(true, false, PasskeyAssertionFailure.InvalidCredential)]
+    [InlineData(false, true, PasskeyAssertionFailure.InvalidUserHandle)]
+    public async Task VerifyAsync_StoredCredentialOwnershipMismatch_IsRejected(
+        bool wrongStoredCredential,
+        bool wrongStoredUserHandle,
+        PasskeyAssertionFailure expectedFailure)
+    {
+        using var assertion = TestAssertion.Create(
+            wrongStoredCredential: wrongStoredCredential,
+            wrongStoredUserHandle: wrongStoredUserHandle);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(expectedFailure, result.Failure);
+    }
+
+    /// <summary>Verifies a positive authenticator counter cannot roll backwards.</summary>
+    [Fact]
+    public async Task VerifyAsync_AuthenticatorCounterRollback_IsRejected()
+    {
+        using var assertion = TestAssertion.Create(signCount: 5, storedSignCount: 6);
+        var verifier = CreateVerifier();
+
+        var result = await verifier.VerifyAsync(assertion.Input, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(PasskeyAssertionFailure.InvalidSignCount, result.Failure);
+    }
+
+    private static PasskeyAssertionVerifier CreateVerifier()
+    {
+        var options = new PasskeyWebAuthnOptions
+        {
+            RpId = RpId,
+            RpName = "MALIEV Test",
+            AllowedOrigins = [Origin],
+            TimeoutMilliseconds = 300_000,
+            ChallengeSize = 32
+        };
+        var library = new Fido2(new Fido2Configuration
+        {
+            ServerDomain = options.RpId,
+            ServerName = options.RpName,
+            Origins = options.AllowedOrigins.ToHashSet(StringComparer.Ordinal),
+            Timeout = (uint)options.TimeoutMilliseconds,
+            ChallengeSize = options.ChallengeSize
+        });
+        return new PasskeyAssertionVerifier(
+            library,
+            Options.Create(options),
+            NullLogger<PasskeyAssertionVerifier>.Instance);
+    }
+
+    private sealed class TestAssertion : IDisposable
+    {
+        private readonly ECDsa _key;
+
+        private TestAssertion(ECDsa key, PasskeyAssertionVerificationInput input)
+        {
+            _key = key;
+            Input = input;
+        }
+
+        public PasskeyAssertionVerificationInput Input { get; }
+
+        public static TestAssertion Create(
+            string origin = Origin,
+            bool crossOrigin = false,
+            string? topOrigin = null,
+            string type = "webauthn.get",
+            bool useWrongChallenge = false,
+            byte flags = 0x05,
+            uint signCount = 1,
+            uint storedSignCount = 0,
+            bool storedBackupEligible = false,
+            bool includeUserHandle = true,
+            string authenticatorRpId = RpId,
+            bool tamperSignature = false,
+            bool wrongStoredCredential = false,
+            bool wrongStoredUserHandle = false)
+        {
+            var challenge = RandomNumberGenerator.GetBytes(32);
+            var credentialId = RandomNumberGenerator.GetBytes(32);
+            var userHandle = RandomNumberGenerator.GetBytes(16);
+            var options = new AssertionOptions
+            {
+                Challenge = challenge,
+                Timeout = 300_000,
+                RpId = RpId,
+                AllowCredentials = [],
+                UserVerification = UserVerificationRequirement.Required,
+                Extensions = null
+            };
+            var clientDataValues = new Dictionary<string, object?>
+            {
+                ["type"] = type,
+                ["challenge"] = ToBase64Url(useWrongChallenge
+                    ? RandomNumberGenerator.GetBytes(32)
+                    : challenge),
+                ["origin"] = origin,
+                ["crossOrigin"] = crossOrigin
+            };
+            if (topOrigin is not null)
+            {
+                clientDataValues["topOrigin"] = topOrigin;
+            }
+            var clientData = JsonSerializer.SerializeToUtf8Bytes(clientDataValues);
+            var authenticatorData = new byte[37];
+            SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(authenticatorRpId)).CopyTo(authenticatorData, 0);
+            authenticatorData[32] = flags;
+            BinaryPrimitives.WriteUInt32BigEndian(authenticatorData.AsSpan(33, 4), signCount);
+
+            var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+            var publicKey = new CredentialPublicKey(key, COSE.Algorithm.ES256).GetBytes();
+            var signedData = new byte[authenticatorData.Length + SHA256.HashSizeInBytes];
+            authenticatorData.CopyTo(signedData, 0);
+            SHA256.HashData(clientData).CopyTo(signedData, authenticatorData.Length);
+            var signature = key.SignData(
+                signedData,
+                HashAlgorithmName.SHA256,
+                DSASignatureFormat.Rfc3279DerSequence);
+            if (tamperSignature)
+            {
+                signature[^1] ^= 0x01;
+            }
+
+            var storedCredentialId = wrongStoredCredential
+                ? RandomNumberGenerator.GetBytes(32)
+                : credentialId;
+            var storedUserHandle = wrongStoredUserHandle
+                ? RandomNumberGenerator.GetBytes(16)
+                : userHandle;
+
+            return new TestAssertion(key, new PasskeyAssertionVerificationInput(
+                AssertionOptionsJson: options.ToJson(),
+                CredentialId: ToBase64Url(credentialId),
+                AuthenticatorData: ToBase64Url(authenticatorData),
+                ClientDataJson: ToBase64Url(clientData),
+                Signature: ToBase64Url(signature),
+                UserHandle: includeUserHandle ? ToBase64Url(userHandle) : null,
+                StoredCredentialId: storedCredentialId,
+                StoredPublicKeyCose: publicKey,
+                StoredUserHandle: storedUserHandle,
+                StoredSignCount: storedSignCount,
+                StoredBackupEligible: storedBackupEligible));
+        }
+
+        public void Dispose() => _key.Dispose();
+
+        private static string ToBase64Url(byte[] value) =>
+            Convert.ToBase64String(value).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}

--- a/Maliev.AuthService.Tests/Unit/PasskeyAuthenticationControllerTests.cs
+++ b/Maliev.AuthService.Tests/Unit/PasskeyAuthenticationControllerTests.cs
@@ -113,6 +113,7 @@ public sealed class PasskeyAuthenticationControllerTests
     /// <summary>Verifies invalid identity and retryable failures have distinct generic HTTP semantics.</summary>
     [Theory]
     [InlineData("passkey_identity_invalid", StatusCodes.Status401Unauthorized)]
+    [InlineData("passkey_unavailable", StatusCodes.Status503ServiceUnavailable)]
     [InlineData("passkey_temporarily_unavailable", StatusCodes.Status503ServiceUnavailable)]
     public async Task CompletePasskeyAuthentication_FailedVerification_DoesNotReturnIdentity(
         string internalError,

--- a/Maliev.AuthService.Tests/Unit/PasskeyAuthenticationControllerTests.cs
+++ b/Maliev.AuthService.Tests/Unit/PasskeyAuthenticationControllerTests.cs
@@ -46,6 +46,29 @@ public sealed class PasskeyAuthenticationControllerTests
         passkeyService.VerifyAll();
     }
 
+    /// <summary>Verifies a saturated or unavailable ceremony store returns one generic retryable response.</summary>
+    [Fact]
+    public async Task BeginPasskeyAuthentication_CeremonyUnavailable_ReturnsGenericServiceUnavailable()
+    {
+        var passkeyService = new Mock<IPasskeyService>();
+        passkeyService.Setup(service => service.BeginAuthenticationAsync(
+                It.IsAny<PasskeyAuthBeginRequest>(),
+                "WebBff",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PasskeyAuthBeginResponse?)null);
+        var controller = CreateController(passkeyService.Object, "WebBff");
+
+        var result = await controller.Begin(
+            new PasskeyAuthBeginRequest { Application = "web" },
+            CancellationToken.None);
+
+        var response = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, response.StatusCode);
+        var error = Assert.IsType<ErrorResponse>(response.Value);
+        Assert.Equal("passkey_temporarily_unavailable", error.Error);
+        passkeyService.VerifyAll();
+    }
+
     /// <summary>Verifies wrong service/application pairs fail before ceremony creation.</summary>
     [Theory]
     [InlineData("QuoteEngineBff", "web")]

--- a/Maliev.AuthService.Tests/Unit/PasskeyAuthenticationControllerTests.cs
+++ b/Maliev.AuthService.Tests/Unit/PasskeyAuthenticationControllerTests.cs
@@ -1,0 +1,170 @@
+using System.Security.Claims;
+using Maliev.AuthService.Api.Controllers;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Application.DTOs.Response;
+using Maliev.AuthService.Application.Interfaces;
+using Maliev.AuthService.Domain.Entities;
+using Maliev.AuthService.Infrastructure.Security;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+/// <summary>
+/// Verifies AuthService binds passkey ceremonies to the configured service caller and application.
+/// </summary>
+public sealed class PasskeyAuthenticationControllerTests
+{
+    /// <summary>Verifies an allowed Web BFF caller reaches the service with server identity.</summary>
+    [Fact]
+    public async Task BeginPasskeyAuthentication_BoundWebCaller_ReturnsOneTimeOptions()
+    {
+        var passkeyService = new Mock<IPasskeyService>();
+        passkeyService.Setup(service => service.BeginAuthenticationAsync(
+                It.IsAny<PasskeyAuthBeginRequest>(),
+                "WebBff",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PasskeyAuthBeginResponse(
+                new string('A', 43),
+                DateTime.UtcNow.AddMinutes(5),
+                "maliev.test",
+                new string('B', 43),
+                [],
+                "required",
+                300_000));
+        var controller = CreateController(passkeyService.Object, "WebBff");
+
+        var result = await controller.Begin(
+            new PasskeyAuthBeginRequest { Application = "web" },
+            CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        passkeyService.VerifyAll();
+    }
+
+    /// <summary>Verifies wrong service/application pairs fail before ceremony creation.</summary>
+    [Theory]
+    [InlineData("QuoteEngineBff", "web")]
+    [InlineData("WebBff", "quote-engine")]
+    [InlineData("", "web")]
+    public async Task BeginPasskeyAuthentication_UnboundCaller_IsForbidden(
+        string serviceName,
+        string application)
+    {
+        var passkeyService = new Mock<IPasskeyService>();
+        var controller = CreateController(passkeyService.Object, serviceName);
+
+        var result = await controller.Begin(
+            new PasskeyAuthBeginRequest { Application = application },
+            CancellationToken.None);
+
+        Assert.IsType<ForbidResult>(result);
+        passkeyService.VerifyNoOtherCalls();
+    }
+
+    /// <summary>Verifies caller-supplied principal scoping is rejected to prevent enumeration.</summary>
+    [Fact]
+    public async Task BeginPasskeyAuthentication_PrincipalScopedRequest_IsRejected()
+    {
+        var passkeyService = new Mock<IPasskeyService>();
+        var controller = CreateController(passkeyService.Object, "WebBff");
+
+        var result = await controller.Begin(
+            new PasskeyAuthBeginRequest
+            {
+                Application = "web",
+                PrincipalId = Guid.NewGuid()
+            },
+            CancellationToken.None);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var error = Assert.IsType<ErrorResponse>(badRequest.Value);
+        Assert.Equal("passkey_flow_invalid", error.Error);
+        passkeyService.VerifyNoOtherCalls();
+    }
+
+    /// <summary>Verifies invalid identity and retryable failures have distinct generic HTTP semantics.</summary>
+    [Theory]
+    [InlineData("passkey_identity_invalid", StatusCodes.Status401Unauthorized)]
+    [InlineData("passkey_temporarily_unavailable", StatusCodes.Status503ServiceUnavailable)]
+    public async Task CompletePasskeyAuthentication_FailedVerification_DoesNotReturnIdentity(
+        string internalError,
+        int expectedStatus)
+    {
+        var passkeyService = new Mock<IPasskeyService>();
+        passkeyService.Setup(service => service.CompleteAuthenticationAsync(
+                It.IsAny<PasskeyAuthCompleteRequest>(),
+                "WebBff",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PasskeyAuthCompleteResponse(false, internalError, null, null));
+        var controller = CreateController(passkeyService.Object, "WebBff");
+
+        var result = await controller.Complete(
+            new PasskeyAuthCompleteRequest
+            {
+                Application = "web",
+                FlowId = new string('A', 43),
+                CredentialId = "credential",
+                AuthenticatorData = "data",
+                ClientDataJson = "client",
+                Signature = "signature",
+                UserHandle = "handle"
+            },
+            CancellationToken.None);
+
+        var response = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(expectedStatus, response.StatusCode);
+        var error = Assert.IsType<ErrorResponse>(response.Value);
+        Assert.Equal(
+            expectedStatus == StatusCodes.Status503ServiceUnavailable
+                ? "passkey_temporarily_unavailable"
+                : "authentication_failed",
+            error.Error);
+        Assert.DoesNotContain(
+            "credential",
+            error.ErrorDescription ?? string.Empty,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static PasskeyAuthenticationController CreateController(
+        IPasskeyService passkeyService,
+        string serviceName)
+    {
+        var options = Options.Create(new PasskeyWebAuthnOptions
+        {
+            Bindings = new Dictionary<string, PasskeyApplicationBinding>
+            {
+                ["web"] = new()
+                {
+                    ServiceName = "WebBff",
+                    PrincipalType = UserType.Customer
+                }
+            }
+        });
+        var controller = new PasskeyAuthenticationController(
+            passkeyService,
+            options,
+            NullLogger<PasskeyAuthenticationController>.Instance);
+        var claims = new List<Claim>
+        {
+            new("user_type", "service")
+        };
+        if (!string.IsNullOrWhiteSpace(serviceName))
+        {
+            claims.Add(new Claim("service_name", serviceName));
+        }
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "test")),
+                TraceIdentifier = "passkey-controller-test"
+            }
+        };
+        return controller;
+    }
+}

--- a/Maliev.AuthService.Tests/Unit/PasskeyEndpointContainmentTests.cs
+++ b/Maliev.AuthService.Tests/Unit/PasskeyEndpointContainmentTests.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using Maliev.Aspire.ServiceDefaults.Authorization;
+using Maliev.AuthService.Api.Authorization;
+using Maliev.AuthService.Api.Controllers;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Application.DTOs.Response;
+using Maliev.AuthService.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+/// <summary>
+/// Verifies the temporary passkey endpoint containment boundary.
+/// </summary>
+public sealed class PasskeyEndpointContainmentTests
+{
+    /// <summary>
+    /// Verifies passkey registration cannot reach the incomplete registration service.
+    /// </summary>
+    [Fact]
+    public async Task BeginPasskeyRegistration_WhenRegistrationIsUnavailable_ReturnsServiceUnavailableWithoutInvokingService()
+    {
+        var passkeyService = CreatePasskeyServiceMock();
+        var controller = CreateController(passkeyService.Object);
+
+        var result = await controller.BeginPasskeyRegistration(
+            new PasskeyRegistrationBeginRequest { PrincipalId = Guid.NewGuid() },
+            CancellationToken.None);
+
+        AssertRegistrationUnavailable(result);
+        passkeyService.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// Verifies passkey registration completion cannot reach the incomplete registration service.
+    /// </summary>
+    [Fact]
+    public async Task CompletePasskeyRegistration_WhenRegistrationIsUnavailable_ReturnsServiceUnavailableWithoutInvokingService()
+    {
+        var passkeyService = CreatePasskeyServiceMock();
+        var controller = CreateController(passkeyService.Object);
+
+        var result = await controller.CompletePasskeyRegistration(
+            new PasskeyRegistrationCompleteRequest
+            {
+                PrincipalId = Guid.NewGuid(),
+                CredentialId = "credential-id",
+                PublicKey = "public-key",
+                DeviceName = "Test device"
+            },
+            CancellationToken.None);
+
+        AssertRegistrationUnavailable(result);
+        passkeyService.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// Verifies passkey credential discovery cannot reach the incomplete registration service.
+    /// </summary>
+    [Fact]
+    public async Task ListPasskeyCredentials_WhenRegistrationIsUnavailable_ReturnsServiceUnavailableWithoutInvokingService()
+    {
+        var passkeyService = CreatePasskeyServiceMock();
+        var controller = CreateController(passkeyService.Object);
+
+        var result = await controller.ListPasskeyCredentials(Guid.NewGuid(), CancellationToken.None);
+
+        AssertRegistrationUnavailable(result);
+        passkeyService.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// Verifies passkey credential deletion cannot reach the incomplete registration service.
+    /// </summary>
+    [Fact]
+    public async Task DeletePasskeyCredential_WhenRegistrationIsUnavailable_ReturnsServiceUnavailableWithoutInvokingService()
+    {
+        var passkeyService = CreatePasskeyServiceMock();
+        var controller = CreateController(passkeyService.Object);
+
+        var result = await controller.DeletePasskeyCredential(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            CancellationToken.None);
+
+        AssertRegistrationUnavailable(result);
+        passkeyService.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// Verifies every passkey endpoint is restricted to trusted identity-exchange callers.
+    /// </summary>
+    /// <param name="methodName">The controller action name.</param>
+    [Theory]
+    [InlineData(nameof(AuthenticationController.BeginPasskeyRegistration))]
+    [InlineData(nameof(AuthenticationController.CompletePasskeyRegistration))]
+    [InlineData(nameof(AuthenticationController.BeginPasskeyAuthentication))]
+    [InlineData(nameof(AuthenticationController.CompletePasskeyAuthentication))]
+    [InlineData(nameof(AuthenticationController.ListPasskeyCredentials))]
+    [InlineData(nameof(AuthenticationController.DeletePasskeyCredential))]
+    public void PasskeyAction_RequiresIdentityExchangePermission(string methodName)
+    {
+        var method = typeof(AuthenticationController).GetMethod(methodName);
+
+        var permission = method?.GetCustomAttribute<RequirePermissionAttribute>();
+
+        Assert.NotNull(permission);
+        Assert.Equal(AuthPermissions.ExchangeIdentities, permission.Permission);
+    }
+
+    private static AuthenticationController CreateController(IPasskeyService passkeyService)
+    {
+        return new AuthenticationController(
+            Mock.Of<IAuthenticationService>(),
+            Mock.Of<IEmailVerificationService>(),
+            passkeyService,
+            Mock.Of<IGoogleIdentityNonceService>(),
+            new ConfigurationBuilder().Build(),
+            NullLogger<AuthenticationController>.Instance);
+    }
+
+    private static Mock<IPasskeyService> CreatePasskeyServiceMock()
+    {
+        var mock = new Mock<IPasskeyService>();
+        mock.Setup(service => service.BeginRegistrationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PasskeyRegistrationBeginResponse)null!);
+        mock.Setup(service => service.CompleteRegistrationAsync(
+                It.IsAny<PasskeyRegistrationCompleteRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PasskeyRegistrationCompleteResponse(true, null));
+        mock.Setup(service => service.ListCredentialsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PasskeyListResponse([]));
+        mock.Setup(service => service.DeleteCredentialAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return mock;
+    }
+
+    private static void AssertRegistrationUnavailable(IActionResult actionResult)
+    {
+        var result = Assert.IsType<ObjectResult>(actionResult);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+        var error = Assert.IsType<ErrorResponse>(result.Value);
+        Assert.Equal("passkey_registration_unavailable", error.Error);
+    }
+}

--- a/Maliev.AuthService.Tests/Unit/PasskeyEndpointContainmentTests.cs
+++ b/Maliev.AuthService.Tests/Unit/PasskeyEndpointContainmentTests.cs
@@ -26,7 +26,7 @@ public sealed class PasskeyEndpointContainmentTests
     public async Task BeginPasskeyRegistration_WhenRegistrationIsUnavailable_ReturnsServiceUnavailableWithoutInvokingService()
     {
         var passkeyService = CreatePasskeyServiceMock();
-        var controller = CreateController(passkeyService.Object);
+        var controller = CreateController();
 
         var result = await controller.BeginPasskeyRegistration(
             new PasskeyRegistrationBeginRequest { PrincipalId = Guid.NewGuid() },
@@ -43,7 +43,7 @@ public sealed class PasskeyEndpointContainmentTests
     public async Task CompletePasskeyRegistration_WhenRegistrationIsUnavailable_ReturnsServiceUnavailableWithoutInvokingService()
     {
         var passkeyService = CreatePasskeyServiceMock();
-        var controller = CreateController(passkeyService.Object);
+        var controller = CreateController();
 
         var result = await controller.CompletePasskeyRegistration(
             new PasskeyRegistrationCompleteRequest
@@ -66,7 +66,7 @@ public sealed class PasskeyEndpointContainmentTests
     public async Task ListPasskeyCredentials_WhenRegistrationIsUnavailable_ReturnsServiceUnavailableWithoutInvokingService()
     {
         var passkeyService = CreatePasskeyServiceMock();
-        var controller = CreateController(passkeyService.Object);
+        var controller = CreateController();
 
         var result = await controller.ListPasskeyCredentials(Guid.NewGuid(), CancellationToken.None);
 
@@ -81,7 +81,7 @@ public sealed class PasskeyEndpointContainmentTests
     public async Task DeletePasskeyCredential_WhenRegistrationIsUnavailable_ReturnsServiceUnavailableWithoutInvokingService()
     {
         var passkeyService = CreatePasskeyServiceMock();
-        var controller = CreateController(passkeyService.Object);
+        var controller = CreateController();
 
         var result = await controller.DeletePasskeyCredential(
             Guid.NewGuid(),
@@ -92,20 +92,36 @@ public sealed class PasskeyEndpointContainmentTests
         passkeyService.VerifyNoOtherCalls();
     }
 
+    /// <summary>Verifies the legacy v1 authentication routes stay present but fail closed.</summary>
+    [Fact]
+    public void LegacyPasskeyAuthentication_WhenCalled_ReturnsServiceUnavailable()
+    {
+        var controller = CreateController();
+
+        var begin = controller.BeginPasskeyAuthentication(CancellationToken.None);
+        var complete = controller.CompletePasskeyAuthentication(CancellationToken.None);
+
+        AssertAuthenticationUnavailable(begin);
+        AssertAuthenticationUnavailable(complete);
+    }
+
     /// <summary>
     /// Verifies every passkey endpoint is restricted to trusted identity-exchange callers.
     /// </summary>
+    /// <param name="controllerType">The controller that owns the action.</param>
     /// <param name="methodName">The controller action name.</param>
     [Theory]
-    [InlineData(nameof(AuthenticationController.BeginPasskeyRegistration))]
-    [InlineData(nameof(AuthenticationController.CompletePasskeyRegistration))]
-    [InlineData(nameof(AuthenticationController.BeginPasskeyAuthentication))]
-    [InlineData(nameof(AuthenticationController.CompletePasskeyAuthentication))]
-    [InlineData(nameof(AuthenticationController.ListPasskeyCredentials))]
-    [InlineData(nameof(AuthenticationController.DeletePasskeyCredential))]
-    public void PasskeyAction_RequiresIdentityExchangePermission(string methodName)
+    [InlineData(typeof(AuthenticationController), nameof(AuthenticationController.BeginPasskeyRegistration))]
+    [InlineData(typeof(AuthenticationController), nameof(AuthenticationController.CompletePasskeyRegistration))]
+    [InlineData(typeof(AuthenticationController), nameof(AuthenticationController.BeginPasskeyAuthentication))]
+    [InlineData(typeof(AuthenticationController), nameof(AuthenticationController.CompletePasskeyAuthentication))]
+    [InlineData(typeof(AuthenticationController), nameof(AuthenticationController.ListPasskeyCredentials))]
+    [InlineData(typeof(AuthenticationController), nameof(AuthenticationController.DeletePasskeyCredential))]
+    [InlineData(typeof(PasskeyAuthenticationController), nameof(PasskeyAuthenticationController.Begin))]
+    [InlineData(typeof(PasskeyAuthenticationController), nameof(PasskeyAuthenticationController.Complete))]
+    public void PasskeyAction_RequiresIdentityExchangePermission(Type controllerType, string methodName)
     {
-        var method = typeof(AuthenticationController).GetMethod(methodName);
+        var method = controllerType.GetMethod(methodName);
 
         var permission = method?.GetCustomAttribute<RequirePermissionAttribute>();
 
@@ -113,12 +129,11 @@ public sealed class PasskeyEndpointContainmentTests
         Assert.Equal(AuthPermissions.ExchangeIdentities, permission.Permission);
     }
 
-    private static AuthenticationController CreateController(IPasskeyService passkeyService)
+    private static AuthenticationController CreateController()
     {
         return new AuthenticationController(
             Mock.Of<IAuthenticationService>(),
             Mock.Of<IEmailVerificationService>(),
-            passkeyService,
             Mock.Of<IGoogleIdentityNonceService>(),
             new ConfigurationBuilder().Build(),
             NullLogger<AuthenticationController>.Instance);
@@ -126,21 +141,7 @@ public sealed class PasskeyEndpointContainmentTests
 
     private static Mock<IPasskeyService> CreatePasskeyServiceMock()
     {
-        var mock = new Mock<IPasskeyService>();
-        mock.Setup(service => service.BeginRegistrationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((PasskeyRegistrationBeginResponse)null!);
-        mock.Setup(service => service.CompleteRegistrationAsync(
-                It.IsAny<PasskeyRegistrationCompleteRequest>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new PasskeyRegistrationCompleteResponse(true, null));
-        mock.Setup(service => service.ListCredentialsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new PasskeyListResponse([]));
-        mock.Setup(service => service.DeleteCredentialAsync(
-                It.IsAny<Guid>(),
-                It.IsAny<Guid>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-        return mock;
+        return new Mock<IPasskeyService>();
     }
 
     private static void AssertRegistrationUnavailable(IActionResult actionResult)
@@ -149,5 +150,13 @@ public sealed class PasskeyEndpointContainmentTests
         Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
         var error = Assert.IsType<ErrorResponse>(result.Value);
         Assert.Equal("passkey_registration_unavailable", error.Error);
+    }
+
+    private static void AssertAuthenticationUnavailable(IActionResult actionResult)
+    {
+        var result = Assert.IsType<ObjectResult>(actionResult);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+        var error = Assert.IsType<ErrorResponse>(result.Value);
+        Assert.Equal("passkey_authentication_unavailable", error.Error);
     }
 }

--- a/docs/superpowers/plans/2026-07-11-passkey-authentication-hardening.md
+++ b/docs/superpowers/plans/2026-07-11-passkey-authentication-hardening.md
@@ -1,0 +1,160 @@
+# Passkey Authentication Hardening Implementation Plan
+
+> **Tracking:** `MALIEV-Co-Ltd/maliev-ops#2`
+
+## Goal
+
+Close the reachable `Maliev.Web` customer-cookie bypass, then permit passkey sign-in only through a service-authenticated AuthService WebAuthn assertion ceremony that is application-bound, expires, and can be consumed exactly once.
+
+This plan deliberately keeps passkey registration, listing, and deletion unavailable. Existing passkey rows were populated from browser-supplied public keys without attestation verification and therefore cannot be trusted. A later customer-session-scoped registration slice must re-enrol credentials using verified attestation before the feature is exposed in the UI.
+
+## Security invariants
+
+- The browser never supplies a trusted principal ID, email, customer ID, application/audience, return URL after flow creation, or credential public key.
+- The Web BFF supplies the fixed `web` application value and calls AuthService with its service identity.
+- AuthService binds `application=web` to the configured Web BFF service caller.
+- The server-generated assertion options, challenge, RP ID, allowed origins, service caller, application, and expiry are persisted as one ceremony.
+- Completion atomically consumes the ceremony before returning an identity; invalid and replayed attempts never return a principal.
+- WebAuthn parsing and cryptographic verification use `Fido2` rather than MALIEV-authored cryptography.
+- Only credentials marked as produced by a verified registration version are eligible for authentication. Existing rows remain quarantined.
+- Web resolves the customer only after AuthService verification, confirms the returned principal matches CustomerService, and uses canonical customer data for the cookie.
+- Every failure path is generic, emits no identity cookie, and logs only outcome/correlation metadata.
+
+## Task 1: Web containment regression and fix
+
+**Files**
+
+- Add: `Maliev.Web.Tests/PasskeySignInFlowTests.cs`
+- Modify: `Maliev.Web.Bff/Controllers/AuthController.cs`
+- Modify: `Maliev.Web.Bff/wwwroot/js/maliev-passkey.js`
+
+**Steps**
+
+1. Add a full HTTP test that obtains a real antiforgery token, posts a victim `PrincipalId` and forged email to `/auth/passkey-sign-in`, and proves the current endpoint issues a cookie (RED).
+2. Change the legacy endpoint to return `410 Gone` with `passkey_flow_retired`, without querying CustomerService or issuing a cookie.
+3. Remove `PasskeySignInRequest` and `submitPasskeySignIn`; retain only browser assertion helpers needed by the replacement flow.
+4. Prove the request remains anonymous and no `__Secure-Maliev.Identity` cookie is emitted (GREEN).
+5. Commit the containment slice in `Maliev.Web`.
+
+## Task 2: AuthService containment and authorization
+
+**Files**
+
+- Add: `Maliev.AuthService.Tests/Contract/PasskeyEndpointContainmentTests.cs`
+- Modify: `Maliev.AuthService.Api/Controllers/AuthenticationController.cs`
+- Modify: `Maliev.AuthService.Api/Authorization/AuthPermissions.cs` only if a canonical existing permission cannot express the boundary
+
+**Steps**
+
+1. Add metadata/HTTP tests proving passkey registration, listing, and deletion cannot invoke `IPasskeyService` and are unavailable to anonymous callers (RED).
+2. Require `AuthPermissions.ExchangeIdentities` for authentication begin/complete.
+3. Return `503 passkey_registration_unavailable` from register begin/complete/list/delete until verified registration is implemented.
+4. Keep the current v1 route names so clients receive an explicit, non-success response instead of silently falling through.
+5. Commit the AuthService containment slice.
+
+## Task 3: Persist single-use assertion ceremonies and quarantine old credentials
+
+**Files**
+
+- Add: `Maliev.AuthService.Domain/Entities/PasskeyCeremony.cs`
+- Add: `Maliev.AuthService.Infrastructure/Configurations/PasskeyCeremonyConfiguration.cs`
+- Modify: `Maliev.AuthService.Domain/Entities/PasskeyCredential.cs`
+- Modify: `Maliev.AuthService.Infrastructure/Configurations/PasskeyCredentialConfiguration.cs`
+- Modify: `Maliev.AuthService.Infrastructure/DbContexts/AuthDbContext.cs`
+- Add: generated EF migration and snapshot update
+- Add: focused integration tests under `Maliev.AuthService.Tests/Integration`
+
+**Steps**
+
+1. Add an assertion-ceremony table containing an opaque flow ID hash, challenge hash, serialized original options, service caller, application, optional principal scope, creation time, and expiry.
+2. Add indexes for unique flow/challenge hashes and expiry cleanup.
+3. Implement read-then-atomic-delete consumption: read the candidate options, then `ExecuteDeleteAsync` with the same ID/application/service/expiry predicates; only one concurrent caller may receive success.
+4. Add `VerificationVersion`, user handle, backup state, and required verified-key storage fields to passkey credentials. Migration defaults existing rows to version `0`; authentication accepts only the new verified version.
+5. Add Testcontainers integration tests for expiry, wrong application/service, sequential replay, and concurrent replay.
+6. Review the generated migration for additive-only schema changes, indexes, defaults, and PostgreSQL `xmin` behavior.
+
+## Task 4: Replace custom assertion crypto with Fido2
+
+**Files**
+
+- Modify: `Maliev.AuthService.Infrastructure/Maliev.AuthService.Infrastructure.csproj`
+- Modify: `Maliev.AuthService.Api/Program.cs`
+- Modify: `Maliev.AuthService.Application/DTOs/Request/PasskeyRequests.cs`
+- Modify: `Maliev.AuthService.Application/DTOs/Response/PasskeyResponses.cs`
+- Modify: `Maliev.AuthService.Application/Interfaces/IPasskeyService.cs`
+- Replace authentication logic in: `Maliev.AuthService.Infrastructure/Services/PasskeyService.cs`
+- Add: focused unit/component tests under `Maliev.AuthService.Tests`
+
+**Steps**
+
+1. Pin stable `Fido2` 4.0.1 and configure RP ID, RP name, challenge size, timeout, and an exact origin allowlist. Production configuration must fail closed when incomplete.
+2. Make begin accept the server-owned application and controller-resolved service caller, generate `AssertionOptions`, persist them, and return additive `flow_id`/`expires_at_utc` fields with the existing option fields.
+3. Make complete accept the opaque flow ID and Base64URL assertion bytes. Do not accept principal/email/customer claims.
+4. Atomically consume the ceremony and call `IFido2.MakeAssertionAsync` with the original options, stored verified public key/counter, and a user-handle ownership callback.
+5. Update sign count and backup state with optimistic concurrency. Map all verification failures to one generic authentication failure.
+6. Add tests covering wrong challenge, type, origin, RP ID, UP/UV flags, signature, user handle, counter, expiry, application, caller, and replay plus a valid vector.
+7. Add snake-case request/response contract tests.
+
+## Task 5: Bind AuthService routes to the Web BFF
+
+**Files**
+
+- Modify: `Maliev.AuthService.Api/Controllers/AuthenticationController.cs`
+- Modify: AuthService test configuration and contract tests
+
+**Steps**
+
+1. Generalize the existing Google exchange caller-binding pattern for passkey authentication.
+2. Require `user_type=service`, the configured service name, fixed `application=web`, and `AuthPermissions.ExchangeIdentities`.
+3. Ensure wrong service/application returns `403` before ceremony creation or consumption.
+4. Add outcome/correlation logs without credential IDs, assertion bytes, challenge values, or customer information.
+
+## Task 6: Add the same-origin Web BFF assertion flow
+
+**Files**
+
+- Add: `Maliev.Web.Bff/Security/PasskeyFlowProtector.cs`
+- Modify: `Maliev.Web.Bff/Controllers/AuthController.cs`
+- Modify: `Maliev.Web.Bff/Clients/CheckoutBoundaryClients.cs`
+- Modify: `Maliev.Web.Bff/wwwroot/js/maliev-passkey.js`
+- Extend: `Maliev.Web.Tests/PasskeySignInFlowTests.cs`
+- Update all `IAuthServiceClient` fakes in tests
+
+**Steps**
+
+1. Add `POST /auth/passkey/begin`. It sends `{ application: "web" }` downstream, normalizes the requested return URL, and stores flow ID/return URL in a protected HttpOnly, Secure, SameSite=Strict cookie.
+2. Return camel-case browser options and decode both challenge and every `allowCredentials[].id` before `navigator.credentials.get`.
+3. Add `POST /auth/passkey/complete`. It requires the matching protected flow cookie, deletes it before downstream verification, and sends Base64URL assertion fields plus fixed application to AuthService.
+4. On verified success only, resolve CustomerService by the returned principal, assert the canonical principal matches, map canonical customer ID/email/name/profile, and issue the shared customer cookie.
+5. Map malformed flow to `400`, invalid/replayed identity to `401`, unavailable AuthService to `503`, and incomplete/mismatched downstream identity to `502`; never reveal whether a principal/credential exists.
+6. Add full HTTP tests for forged legacy fields, missing/malformed flow, invalid/expired/wrong-app/replayed assertion, incomplete identity, customer mismatch, unavailable dependency, valid sign-in, cookie attributes, and return URL normalization.
+
+## Task 7: Verification and delivery
+
+**AuthService gates**
+
+```powershell
+dotnet test Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj --configuration Release --filter "FullyQualifiedName~Passkey"
+dotnet build Maliev.AuthService.slnx --configuration Release
+dotnet format Maliev.AuthService.slnx --verify-no-changes
+```
+
+**Web gates**
+
+```powershell
+dotnet test Maliev.Web.Tests/Maliev.Web.Tests.csproj --configuration Release --filter "FullyQualifiedName~PasskeySignInFlowTests"
+dotnet build Maliev.Web.slnx --configuration Release
+dotnet format Maliev.Web.slnx --verify-no-changes
+```
+
+**Delivery**
+
+1. Run security review against the complete diffs and re-check browser/BFF/AuthService/CustomerService wire names.
+2. Commit only the validated logical slices listed above.
+3. Push the two `codex/*` branches and open linked PRs against `develop`.
+4. Attach commands, SHAs, migration evidence, and residual registration risk to `maliev-ops#2`.
+5. Keep issue #2 open until the verified assertion flow is merged; create/link a separate P0/P1 issue for verified registration and existing-credential re-enrolment.
+
+## Deployment boundary
+
+No ArgoCD application is enabled by this work. No passkey UI is exposed until secure registration and production RP/origin configuration are complete. `Maliev.Aspire` remains local/system-test orchestration only.


### PR DESCRIPTION
## Summary
- retire the unverified v1 passkey identity and credential-management surfaces
- add service/application/principal-bound v2 passkey assertion ceremonies
- verify WebAuthn assertions with FIDO2, exact RP/origin/challenge/user verification, user-handle, backup, counter, and credential concurrency checks
- persist atomic single-use ceremonies in PostgreSQL and quarantine legacy credentials
- bound outstanding ceremonies with a concurrency-safe per-application quota
- return a retryable unavailable response while the feature is disabled

## Security and rollout
- PasskeyWebAuthn:Enabled remains false
- secure registration/enrollment is intentionally not enabled
- no ArgoCD or deployment configuration is changed
- activation remains gated on public-BFF throttling, trusted proxy verification, and MALIEV-Co-Ltd/maliev-ops#53

## Validation
- 274/274 full AuthService tests
- 74/74 focused passkey tests
- Release build: 0 warnings, 0 errors
- changed-file format and diff checks clean
- dependency vulnerability scan: no known vulnerable packages
- migration SQL and PostgreSQL concurrency paths reviewed

Known baseline: the repository-wide format check still reports pre-existing whitespace in two test-infrastructure files; touched files pass formatting.

Tracking: MALIEV-Co-Ltd/maliev-ops#2