### PR TITLE
feat(auth): manage IAM-backed service identities

### DIFF
--- a/Maliev.AuthService.Api/Authorization/AuthPermissions.cs
+++ b/Maliev.AuthService.Api/Authorization/AuthPermissions.cs
@@ -27,6 +27,18 @@ public static class AuthPermissions
     /// </summary>
     public const string ExchangeIdentities = "auth.identities.exchange";
 
+    /// <summary>Permission to provision least-privilege service identities.</summary>
+    public const string ProvisionServiceIdentities = "auth.service-identities.provision";
+
+    /// <summary>Permission to read service identity metadata.</summary>
+    public const string ReadServiceIdentities = "auth.service-identities.read";
+
+    /// <summary>Permission to rotate service identity secrets.</summary>
+    public const string RotateServiceIdentities = "auth.service-identities.rotate";
+
+    /// <summary>Permission to revoke service identities.</summary>
+    public const string RevokeServiceIdentities = "auth.service-identities.revoke";
+
     /// <summary>
     /// Dictionary of all permissions with their descriptions.
     /// </summary>
@@ -35,6 +47,10 @@ public static class AuthPermissions
         { RevokeTokens, "Can revoke access and refresh tokens" },
         { ViewUsers, "Can view user details and sessions" },
         { ManageUsers, "Can manage user accounts and locks" },
-        { ExchangeIdentities, "Can exchange verified external identities for MALIEV sessions" }
+        { ExchangeIdentities, "Can exchange verified external identities for MALIEV sessions" },
+        { ProvisionServiceIdentities, "Can provision least-privilege service identities" },
+        { ReadServiceIdentities, "Can read service identity metadata" },
+        { RotateServiceIdentities, "Can rotate service identity secrets" },
+        { RevokeServiceIdentities, "Can revoke service identities" }
     });
 }

--- a/Maliev.AuthService.Api/Controllers/ServiceIdentitiesController.cs
+++ b/Maliev.AuthService.Api/Controllers/ServiceIdentitiesController.cs
@@ -1,0 +1,210 @@
+using Asp.Versioning;
+using Maliev.Aspire.ServiceDefaults.Authorization;
+using Maliev.AuthService.Api.Authorization;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Application.Interfaces;
+using Maliev.AuthService.Infrastructure.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+
+namespace Maliev.AuthService.Api.Controllers;
+
+/// <summary>Manages least-privilege workload identities and versioned service credentials.</summary>
+[ApiController]
+[ApiVersion("1")]
+[Route("auth/v{version:apiVersion}/service-identities")]
+public sealed class ServiceIdentitiesController(IServiceIdentityManager manager) : ControllerBase
+{
+    /// <summary>Provisions or resumes an IAM-backed service identity operation.</summary>
+    [HttpPut("{workloadId}")]
+    [RequirePermission(
+        AuthPermissions.ProvisionServiceIdentities,
+        IsCritical = true,
+        RequireLiveCheck = true,
+        AuditPurpose = "Provision service identity")]
+    public async Task<IActionResult> Provision(
+        string workloadId,
+        [FromBody] ProvisionServiceIdentityRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetEmployeeActor(out var actorId) || !TryGetBearerToken(out var bearerToken))
+        {
+            return Forbid();
+        }
+
+        try
+        {
+            var result = await manager.ProvisionAsync(
+                workloadId,
+                request,
+                actorId,
+                bearerToken,
+                cancellationToken);
+            MarkSecretResponseNonCacheable();
+            return Ok(result);
+        }
+        catch (ServiceIdentityConflictException exception)
+        {
+            return Conflict(new { error = exception.Message });
+        }
+        catch (ArgumentException exception)
+        {
+            return BadRequest(new { error = exception.Message });
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "iam_unavailable",
+                error_description = "IAM could not authoritatively provision the workload identity"
+            });
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "iam_unavailable",
+                error_description = "IAM could not authoritatively provision the workload identity"
+            });
+        }
+    }
+
+    /// <summary>Gets metadata for a managed service identity without secret material.</summary>
+    [HttpGet("{workloadId}")]
+    [RequirePermission(
+        AuthPermissions.ReadServiceIdentities,
+        IsCritical = true,
+        RequireLiveCheck = true,
+        AuditPurpose = "Read service identity")]
+    public async Task<IActionResult> Get(string workloadId, CancellationToken cancellationToken)
+    {
+        if (!TryGetEmployeeActor(out _))
+        {
+            return Forbid();
+        }
+
+        try
+        {
+            var result = await manager.GetAsync(workloadId, cancellationToken);
+            return result is null ? NotFound() : Ok(result);
+        }
+        catch (ArgumentException exception)
+        {
+            return BadRequest(new { error = exception.Message });
+        }
+    }
+
+    /// <summary>Rotates a service credential and applies bounded prior-version grace.</summary>
+    [HttpPost("{workloadId}/rotations")]
+    [RequirePermission(
+        AuthPermissions.RotateServiceIdentities,
+        IsCritical = true,
+        RequireLiveCheck = true,
+        AuditPurpose = "Rotate service identity")]
+    public async Task<IActionResult> Rotate(
+        string workloadId,
+        [FromBody] RotateServiceIdentityRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetEmployeeActor(out var actorId))
+        {
+            return Forbid();
+        }
+
+        try
+        {
+            var result = await manager.RotateAsync(workloadId, request, actorId, cancellationToken);
+            MarkSecretResponseNonCacheable();
+            return Ok(result);
+        }
+        catch (ServiceIdentityNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ServiceIdentityConflictException exception)
+        {
+            return Conflict(new { error = exception.Message });
+        }
+        catch (ArgumentException exception)
+        {
+            return BadRequest(new { error = exception.Message });
+        }
+    }
+
+    /// <summary>Logically revokes a service identity and all of its secret versions.</summary>
+    [HttpPost("{workloadId}/revocations")]
+    [RequirePermission(
+        AuthPermissions.RevokeServiceIdentities,
+        IsCritical = true,
+        RequireLiveCheck = true,
+        AuditPurpose = "Revoke service identity")]
+    public async Task<IActionResult> Revoke(
+        string workloadId,
+        [FromBody] RevokeServiceIdentityRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetEmployeeActor(out var actorId))
+        {
+            return Forbid();
+        }
+
+        try
+        {
+            await manager.RevokeAsync(workloadId, request, actorId, cancellationToken);
+            return NoContent();
+        }
+        catch (ServiceIdentityNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ServiceIdentityConflictException exception)
+        {
+            return Conflict(new { error = exception.Message });
+        }
+        catch (ArgumentException exception)
+        {
+            return BadRequest(new { error = exception.Message });
+        }
+    }
+
+    private bool TryGetEmployeeActor(out Guid actorId)
+    {
+        actorId = Guid.Empty;
+        var userTypes = User.FindAll("user_type").Select(claim => claim.Value).ToList();
+        if (userTypes.Count != 1 || userTypes[0] != "employee")
+        {
+            return false;
+        }
+
+        var subjects = User.FindAll("sub").Select(claim => claim.Value).ToList();
+        return subjects.Count == 1 &&
+            Guid.TryParseExact(subjects[0], "D", out actorId) &&
+            actorId != Guid.Empty &&
+            subjects[0] == actorId.ToString("D");
+    }
+
+    private bool TryGetBearerToken(out string token)
+    {
+        token = string.Empty;
+        if (!Request.Headers.TryGetValue(HeaderNames.Authorization, out var values) || values.Count != 1)
+        {
+            return false;
+        }
+
+        const string prefix = "Bearer ";
+        var value = values[0];
+        if (value is null || !value.StartsWith(prefix, StringComparison.Ordinal) || value.Length <= prefix.Length)
+        {
+            return false;
+        }
+
+        token = value[prefix.Length..];
+        return token.Length <= 16_384 && token == token.Trim();
+    }
+
+    private void MarkSecretResponseNonCacheable()
+    {
+        Response.Headers.CacheControl = "no-store";
+        Response.Headers.Pragma = "no-cache";
+    }
+}

--- a/Maliev.AuthService.Api/Controllers/ServiceIdentitiesController.cs
+++ b/Maliev.AuthService.Api/Controllers/ServiceIdentitiesController.cs
@@ -51,6 +51,18 @@ public sealed class ServiceIdentitiesController(IServiceIdentityManager manager)
         {
             return BadRequest(new { error = exception.Message });
         }
+        catch (HttpRequestException exception) when (exception.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            return Forbid();
+        }
+        catch (HttpRequestException exception) when (exception.StatusCode == System.Net.HttpStatusCode.Conflict)
+        {
+            return Conflict(new
+            {
+                error = "iam_conflict",
+                error_description = "IAM rejected the workload identity operation as conflicting"
+            });
+        }
         catch (HttpRequestException)
         {
             return StatusCode(StatusCodes.Status503ServiceUnavailable, new

--- a/Maliev.AuthService.Api/Program.cs
+++ b/Maliev.AuthService.Api/Program.cs
@@ -116,12 +116,14 @@ try
     // Dedicated human-authorized client for IAM workload provisioning. It intentionally
     // has no service-account authentication handler because the controller forwards only
     // the already validated employee bearer token.
-    builder.Services.AddHttpClient<IWorkloadIdentityIamClient, WorkloadIdentityIamClient>(client =>
+    builder.Services.AddWorkloadIdentityIamEndpoint(
+        builder.Configuration.GetSection("Services:IAMService"),
+        builder.Environment);
+    builder.Services.AddHttpClient<IWorkloadIdentityIamClient, WorkloadIdentityIamClient>((services, client) =>
     {
-        var explicitUrl = builder.Configuration["Services:IAMService:BaseUrl"];
-        client.BaseAddress = !string.IsNullOrWhiteSpace(explicitUrl)
-            ? new Uri(explicitUrl)
-            : new Uri("https+http://IAMService");
+        var options = services.GetRequiredService<IOptions<WorkloadIdentityIamEndpointOptions>>().Value;
+        var resolver = services.GetRequiredService<IWorkloadIdentityIamEndpointResolver>();
+        client.BaseAddress = resolver.Resolve(options);
         client.Timeout = TimeSpan.FromSeconds(10);
     }).AddServiceDiscovery();
 

--- a/Maliev.AuthService.Api/Program.cs
+++ b/Maliev.AuthService.Api/Program.cs
@@ -113,6 +113,18 @@ try
     .AddServiceDiscovery()
     .AddHttpMessageHandler<Maliev.Aspire.ServiceDefaults.IAM.ServiceAccountAuthenticationHandler>();
 
+    // Dedicated human-authorized client for IAM workload provisioning. It intentionally
+    // has no service-account authentication handler because the controller forwards only
+    // the already validated employee bearer token.
+    builder.Services.AddHttpClient<IWorkloadIdentityIamClient, WorkloadIdentityIamClient>(client =>
+    {
+        var explicitUrl = builder.Configuration["Services:IAMService:BaseUrl"];
+        client.BaseAddress = !string.IsNullOrWhiteSpace(explicitUrl)
+            ? new Uri(explicitUrl)
+            : new Uri("https+http://IAMService");
+        client.Timeout = TimeSpan.FromSeconds(10);
+    }).AddServiceDiscovery();
+
 
     // IAM Integration
     builder.Services.AddIAMRegistration<AuthIAMRegistrationService>("auth");
@@ -127,6 +139,7 @@ try
     builder.Services.AddSingleton(TimeProvider.System);
     builder.Services.AddScoped<IGoogleIdentityNonceService, GoogleIdentityNonceService>();
     builder.Services.AddScoped<IAuthenticationService, AuthenticationService>();
+    builder.Services.AddScoped<IServiceIdentityManager, ServiceIdentityManager>();
     builder.Services.AddScoped<IEmailVerificationService, EmailVerificationService>();
     builder.Services.AddOptions<ServiceLoginRateLimitOptions>()
         .Bind(builder.Configuration.GetSection("RateLimiting:ServiceLogin"))

--- a/Maliev.AuthService.Application/DTOs/IAM/WorkloadPrincipalModels.cs
+++ b/Maliev.AuthService.Application/DTOs/IAM/WorkloadPrincipalModels.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Maliev.AuthService.Application.DTOs.IAM;
+
+/// <summary>Requests an idempotent server-owned IAM workload profile.</summary>
+public sealed record ProvisionWorkloadPrincipalRequest
+{
+    /// <summary>Gets the profile version.</summary>
+    [Range(1, int.MaxValue)]
+    public required int ProfileVersion { get; init; }
+
+    /// <summary>Gets the shared saga operation identifier.</summary>
+    public required Guid OperationId { get; init; }
+}
+
+/// <summary>Describes IAM's authoritative workload binding.</summary>
+public sealed record WorkloadPrincipalResponse
+{
+    /// <summary>Gets the canonical workload identifier.</summary>
+    public required string WorkloadId { get; init; }
+
+    /// <summary>Gets the IAM principal identifier.</summary>
+    public required Guid PrincipalId { get; init; }
+
+    /// <summary>Gets the applied profile version.</summary>
+    public required int ProfileVersion { get; init; }
+
+    /// <summary>Gets the exact role identifier.</summary>
+    public required string RoleId { get; init; }
+}

--- a/Maliev.AuthService.Application/DTOs/Request/ServiceIdentityRequests.cs
+++ b/Maliev.AuthService.Application/DTOs/Request/ServiceIdentityRequests.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Maliev.AuthService.Application.DTOs.Request;
+
+/// <summary>Requests idempotent provisioning of a service identity.</summary>
+public sealed record ProvisionServiceIdentityRequest
+{
+    /// <summary>Gets the server-owned IAM access profile version.</summary>
+    [Range(1, int.MaxValue)]
+    public required int ProfileVersion { get; init; }
+
+    /// <summary>Gets the caller-generated idempotency operation identifier.</summary>
+    public required Guid OperationId { get; init; }
+
+    /// <summary>Gets the human-readable service name.</summary>
+    [Required, StringLength(100, MinimumLength = 1)]
+    public required string ServiceName { get; init; }
+
+    /// <summary>Gets the bounded hard credential lifetime in days.</summary>
+    [Range(1, 365)]
+    public int HardExpiryDays { get; init; } = 90;
+}
+
+/// <summary>Requests idempotent service secret rotation.</summary>
+public sealed record RotateServiceIdentityRequest
+{
+    /// <summary>Gets the caller-generated idempotency operation identifier.</summary>
+    public required Guid OperationId { get; init; }
+
+    /// <summary>Gets the prior-version overlap in seconds.</summary>
+    [Range(0, 86_400)]
+    public int GracePeriodSeconds { get; init; } = 3_600;
+
+    /// <summary>Gets the bounded hard credential lifetime in days.</summary>
+    [Range(1, 365)]
+    public int HardExpiryDays { get; init; } = 90;
+}
+
+/// <summary>Requests idempotent logical revocation of a service identity.</summary>
+public sealed record RevokeServiceIdentityRequest
+{
+    /// <summary>Gets the caller-generated idempotency operation identifier.</summary>
+    public required Guid OperationId { get; init; }
+}

--- a/Maliev.AuthService.Application/DTOs/Response/ServiceIdentityResponses.cs
+++ b/Maliev.AuthService.Application/DTOs/Response/ServiceIdentityResponses.cs
@@ -1,0 +1,35 @@
+namespace Maliev.AuthService.Application.DTOs.Response;
+
+/// <summary>Returns service identity metadata and, once, a newly generated secret.</summary>
+public sealed record ServiceIdentityResponse
+{
+    /// <summary>Gets the canonical workload identifier.</summary>
+    public required string WorkloadId { get; init; }
+
+    /// <summary>Gets the stable client identifier.</summary>
+    public required string ClientId { get; init; }
+
+    /// <summary>Gets the IAM principal identifier.</summary>
+    public required Guid PrincipalId { get; init; }
+
+    /// <summary>Gets the IAM access profile version.</summary>
+    public required int ProfileVersion { get; init; }
+
+    /// <summary>Gets the exact least-privilege IAM role identifier.</summary>
+    public required string RoleId { get; init; }
+
+    /// <summary>Gets whether the logical identity is active.</summary>
+    public required bool IsActive { get; init; }
+
+    /// <summary>Gets the current secret version number.</summary>
+    public required int CredentialVersion { get; init; }
+
+    /// <summary>Gets the one-time plaintext secret on the first successful create or rotation response only.</summary>
+    public string? ClientSecret { get; init; }
+
+    /// <summary>Gets whether plaintext secret retrieval is available on this response.</summary>
+    public required bool SecretRetrievable { get; init; }
+
+    /// <summary>Gets the hard expiry of the current credential.</summary>
+    public required DateTimeOffset HardExpiresAt { get; init; }
+}

--- a/Maliev.AuthService.Application/Interfaces/IServiceIdentityManager.cs
+++ b/Maliev.AuthService.Application/Interfaces/IServiceIdentityManager.cs
@@ -1,0 +1,35 @@
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Application.DTOs.Response;
+
+namespace Maliev.AuthService.Application.Interfaces;
+
+/// <summary>Manages durable service identity credentials.</summary>
+public interface IServiceIdentityManager
+{
+    /// <summary>Provisions a least-privilege service identity.</summary>
+    Task<ServiceIdentityResponse> ProvisionAsync(
+        string workloadId,
+        ProvisionServiceIdentityRequest request,
+        Guid actorId,
+        string callerBearerToken,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Reads service identity metadata without exposing secret material.</summary>
+    Task<ServiceIdentityResponse?> GetAsync(
+        string workloadId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Rotates a service secret with bounded grace.</summary>
+    Task<ServiceIdentityResponse> RotateAsync(
+        string workloadId,
+        RotateServiceIdentityRequest request,
+        Guid actorId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Logically revokes a service identity and every credential version.</summary>
+    Task RevokeAsync(
+        string workloadId,
+        RevokeServiceIdentityRequest request,
+        Guid actorId,
+        CancellationToken cancellationToken = default);
+}

--- a/Maliev.AuthService.Application/Interfaces/IWorkloadIdentityIamClient.cs
+++ b/Maliev.AuthService.Application/Interfaces/IWorkloadIdentityIamClient.cs
@@ -1,0 +1,14 @@
+using Maliev.AuthService.Application.DTOs.IAM;
+
+namespace Maliev.AuthService.Application.Interfaces;
+
+/// <summary>Calls IAM workload provisioning using the original employee authorization.</summary>
+public interface IWorkloadIdentityIamClient
+{
+    /// <summary>Creates or reconciles an authoritative IAM workload principal.</summary>
+    Task<WorkloadPrincipalResponse> ProvisionAsync(
+        string workloadId,
+        ProvisionWorkloadPrincipalRequest request,
+        string callerBearerToken,
+        CancellationToken cancellationToken = default);
+}

--- a/Maliev.AuthService.Domain/Entities/ServiceCredential.cs
+++ b/Maliev.AuthService.Domain/Entities/ServiceCredential.cs
@@ -23,6 +23,21 @@ public class ServiceCredential
     public Guid? PrincipalId { get; set; }
 
     /// <summary>
+    /// Canonical workload identifier managed by IAM. Null only for legacy credentials.
+    /// </summary>
+    public string? WorkloadId { get; set; }
+
+    /// <summary>
+    /// Server-owned IAM access profile version. Null only for legacy credentials.
+    /// </summary>
+    public int? ProfileVersion { get; set; }
+
+    /// <summary>
+    /// Exact least-privilege IAM role bound to the workload. Null only for legacy credentials.
+    /// </summary>
+    public string? RoleId { get; set; }
+
+    /// <summary>
     /// SHA-256 hash of client secret (64 characters hex)
     /// </summary>
     public string ClientSecretHash { get; set; } = string.Empty;
@@ -46,4 +61,14 @@ public class ServiceCredential
     /// Last update timestamp
     /// </summary>
     public DateTime UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the logical revocation time.
+    /// </summary>
+    public DateTimeOffset? RevokedAt { get; set; }
+
+    /// <summary>
+    /// Gets credential secret versions. Secret plaintext is never persisted.
+    /// </summary>
+    public ICollection<ServiceCredentialVersion> Versions { get; set; } = [];
 }

--- a/Maliev.AuthService.Domain/Entities/ServiceCredentialVersion.cs
+++ b/Maliev.AuthService.Domain/Entities/ServiceCredentialVersion.cs
@@ -1,0 +1,65 @@
+namespace Maliev.AuthService.Domain.Entities;
+
+/// <summary>
+/// Describes the lifecycle state of a hashed service credential version.
+/// </summary>
+public enum ServiceCredentialVersionStatus
+{
+    /// <summary>The hash is staged but cannot authenticate.</summary>
+    Pending = 0,
+
+    /// <summary>The version is the primary active credential.</summary>
+    Active = 1,
+
+    /// <summary>The version is accepted during a bounded rotation overlap.</summary>
+    Grace = 2,
+
+    /// <summary>The version can no longer authenticate.</summary>
+    Revoked = 3
+}
+
+/// <summary>
+/// Stores one immutable hashed secret version for a logical service credential.
+/// </summary>
+public sealed class ServiceCredentialVersion
+{
+    /// <summary>Gets or sets the version identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the owning logical credential identifier.</summary>
+    public Guid ServiceCredentialId { get; set; }
+
+    /// <summary>Gets or sets the monotonically increasing version number.</summary>
+    public int Version { get; set; }
+
+    /// <summary>Gets or sets the SHA-256 hash of a uniformly random 256-bit secret.</summary>
+    public string SecretHash { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the lifecycle status.</summary>
+    public ServiceCredentialVersionStatus Status { get; set; }
+
+    /// <summary>Gets or sets the creation timestamp.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>Gets or sets the activation timestamp.</summary>
+    public DateTimeOffset? ActivatedAt { get; set; }
+
+    /// <summary>Gets or sets the optional grace-period end.</summary>
+    public DateTimeOffset? GraceExpiresAt { get; set; }
+
+    /// <summary>Gets or sets the hard expiry after which this version is always rejected.</summary>
+    public DateTimeOffset HardExpiresAt { get; set; }
+
+    /// <summary>Gets or sets the revocation timestamp.</summary>
+    public DateTimeOffset? RevokedAt { get; set; }
+
+    /// <summary>Gets or sets the owning logical credential.</summary>
+    public ServiceCredential ServiceCredential { get; set; } = null!;
+
+    /// <summary>Returns whether the version is accepted at the supplied instant.</summary>
+    public bool CanAuthenticate(DateTimeOffset now) =>
+        now < HardExpiresAt &&
+        Status is ServiceCredentialVersionStatus.Active or ServiceCredentialVersionStatus.Grace &&
+        (Status != ServiceCredentialVersionStatus.Grace ||
+            GraceExpiresAt.HasValue && now < GraceExpiresAt.Value);
+}

--- a/Maliev.AuthService.Domain/Entities/ServiceIdentityOperation.cs
+++ b/Maliev.AuthService.Domain/Entities/ServiceIdentityOperation.cs
@@ -1,0 +1,72 @@
+namespace Maliev.AuthService.Domain.Entities;
+
+/// <summary>Identifies the durable operation type for a service identity.</summary>
+public enum ServiceIdentityOperationKind
+{
+    /// <summary>Initial identity provisioning.</summary>
+    Provision = 0,
+
+    /// <summary>Credential secret rotation.</summary>
+    Rotate = 1,
+
+    /// <summary>Logical identity revocation.</summary>
+    Revoke = 2
+}
+
+/// <summary>Identifies progress through the durable provisioning saga.</summary>
+public enum ServiceIdentityOperationState
+{
+    /// <summary>The idempotency record is persisted.</summary>
+    Started = 0,
+
+    /// <summary>IAM returned an exact verified workload binding.</summary>
+    IamReady = 1,
+
+    /// <summary>The credential and audit mutation committed atomically.</summary>
+    CredentialCommitted = 2,
+
+    /// <summary>The operation completed successfully.</summary>
+    Completed = 3
+}
+
+/// <summary>
+/// Durable idempotency and recovery record for service identity lifecycle operations.
+/// </summary>
+public sealed class ServiceIdentityOperation
+{
+    /// <summary>Gets or sets the caller-generated operation identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the canonical workload identifier.</summary>
+    public string WorkloadId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the operation kind.</summary>
+    public ServiceIdentityOperationKind Kind { get; set; }
+
+    /// <summary>Gets or sets the SHA-256 hash of the canonical request.</summary>
+    public string RequestHash { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the employee actor subject.</summary>
+    public Guid ActorId { get; set; }
+
+    /// <summary>Gets or sets current saga state.</summary>
+    public ServiceIdentityOperationState State { get; set; }
+
+    /// <summary>Gets or sets the verified IAM principal identifier.</summary>
+    public Guid? IamPrincipalId { get; set; }
+
+    /// <summary>Gets or sets the verified IAM profile version.</summary>
+    public int? IamProfileVersion { get; set; }
+
+    /// <summary>Gets or sets the verified IAM role identifier.</summary>
+    public string? IamRoleId { get; set; }
+
+    /// <summary>Gets or sets the committed credential version identifier.</summary>
+    public Guid? CredentialVersionId { get; set; }
+
+    /// <summary>Gets or sets creation time.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>Gets or sets last update time.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/Maliev.AuthService.Infrastructure/Configurations/ServiceCredentialConfiguration.cs
+++ b/Maliev.AuthService.Infrastructure/Configurations/ServiceCredentialConfiguration.cs
@@ -13,20 +13,32 @@ public class ServiceCredentialConfiguration : IEntityTypeConfiguration<ServiceCr
     /// <param name="builder">The entity type builder.</param>
     public void Configure(EntityTypeBuilder<ServiceCredential> builder)
     {
-        builder.ToTable("service_credentials");
+        builder.ToTable("service_credentials", table =>
+        {
+            table.HasCheckConstraint(
+                "ck_service_credentials_managed_binding",
+                "workload_id IS NULL OR (principal_id IS NOT NULL AND profile_version IS NOT NULL AND profile_version > 0 AND role_id IS NOT NULL)");
+        });
 
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id).HasColumnName("id");
 
         builder.Property(e => e.ClientId).HasColumnName("client_id").HasMaxLength(100).IsRequired();
+        builder.Property(e => e.PrincipalId).HasColumnName("principal_id");
         builder.Property(e => e.ClientSecretHash).HasColumnName("client_secret_hash").HasMaxLength(64).IsRequired();
         builder.Property(e => e.ServiceName).HasColumnName("service_name").HasMaxLength(100).IsRequired();
+        builder.Property(e => e.WorkloadId).HasColumnName("workload_id").HasMaxLength(100);
+        builder.Property(e => e.ProfileVersion).HasColumnName("profile_version");
+        builder.Property(e => e.RoleId).HasColumnName("role_id").HasMaxLength(160);
         builder.Property(e => e.IsActive).HasColumnName("is_active").HasDefaultValue(true);
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").HasDefaultValueSql("NOW()");
         builder.Property(e => e.UpdatedAt).HasColumnName("updated_at").HasDefaultValueSql("NOW()");
+        builder.Property(e => e.RevokedAt).HasColumnName("revoked_at");
 
         // Indexes
         builder.HasIndex(e => e.ClientId).IsUnique().HasDatabaseName("idx_service_credentials_client_id");
+        builder.HasIndex(e => e.WorkloadId).IsUnique().HasFilter("workload_id IS NOT NULL")
+            .HasDatabaseName("idx_service_credentials_workload_id");
         builder.HasIndex(e => e.IsActive).HasDatabaseName("idx_service_credentials_is_active");
 
         builder.Property<uint>("xmin")

--- a/Maliev.AuthService.Infrastructure/Configurations/ServiceCredentialVersionConfiguration.cs
+++ b/Maliev.AuthService.Infrastructure/Configurations/ServiceCredentialVersionConfiguration.cs
@@ -1,0 +1,54 @@
+using Maliev.AuthService.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Maliev.AuthService.Infrastructure.Configurations;
+
+/// <summary>Configures hashed service credential versions.</summary>
+public sealed class ServiceCredentialVersionConfiguration : IEntityTypeConfiguration<ServiceCredentialVersion>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<ServiceCredentialVersion> builder)
+    {
+        builder.ToTable("service_credential_versions", table =>
+        {
+            table.HasCheckConstraint("ck_service_credential_versions_version", "version > 0");
+            table.HasCheckConstraint(
+                "ck_service_credential_versions_hash",
+                "length(secret_hash) = 64 AND secret_hash ~ '^[0-9A-F]{64}$'");
+            table.HasCheckConstraint(
+                "ck_service_credential_versions_status",
+                "status IN ('Pending', 'Active', 'Grace', 'Revoked')");
+            table.HasCheckConstraint(
+                "ck_service_credential_versions_expiry",
+                "hard_expires_at > created_at");
+        });
+
+        builder.HasKey(entity => entity.Id);
+        builder.Property(entity => entity.Id).HasColumnName("id");
+        builder.Property(entity => entity.ServiceCredentialId).HasColumnName("service_credential_id");
+        builder.Property(entity => entity.Version).HasColumnName("version");
+        builder.Property(entity => entity.SecretHash).HasColumnName("secret_hash").HasMaxLength(64).IsRequired();
+        builder.Property(entity => entity.Status).HasColumnName("status").HasConversion<string>().HasMaxLength(16);
+        builder.Property(entity => entity.CreatedAt).HasColumnName("created_at");
+        builder.Property(entity => entity.ActivatedAt).HasColumnName("activated_at");
+        builder.Property(entity => entity.GraceExpiresAt).HasColumnName("grace_expires_at");
+        builder.Property(entity => entity.HardExpiresAt).HasColumnName("hard_expires_at");
+        builder.Property(entity => entity.RevokedAt).HasColumnName("revoked_at");
+
+        builder.HasOne(entity => entity.ServiceCredential)
+            .WithMany(entity => entity.Versions)
+            .HasForeignKey(entity => entity.ServiceCredentialId)
+            .OnDelete(DeleteBehavior.Restrict);
+        builder.HasIndex(entity => new { entity.ServiceCredentialId, entity.Version })
+            .IsUnique()
+            .HasDatabaseName("idx_service_credential_versions_credential_version");
+        builder.HasIndex(entity => new { entity.ServiceCredentialId, entity.Status })
+            .HasDatabaseName("idx_service_credential_versions_credential_status");
+        builder.HasIndex(entity => entity.ServiceCredentialId)
+            .IsUnique()
+            .HasFilter("status = 'Active'")
+            .HasDatabaseName("idx_service_credential_versions_one_active");
+        builder.Property<uint>("xmin").HasColumnType("xid").IsRowVersion();
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Configurations/ServiceIdentityOperationConfiguration.cs
+++ b/Maliev.AuthService.Infrastructure/Configurations/ServiceIdentityOperationConfiguration.cs
@@ -1,0 +1,31 @@
+using Maliev.AuthService.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Maliev.AuthService.Infrastructure.Configurations;
+
+/// <summary>Configures durable service identity lifecycle operations.</summary>
+public sealed class ServiceIdentityOperationConfiguration : IEntityTypeConfiguration<ServiceIdentityOperation>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<ServiceIdentityOperation> builder)
+    {
+        builder.ToTable("service_identity_operations");
+        builder.HasKey(entity => entity.Id);
+        builder.Property(entity => entity.Id).HasColumnName("id");
+        builder.Property(entity => entity.WorkloadId).HasColumnName("workload_id").HasMaxLength(100).IsRequired();
+        builder.Property(entity => entity.Kind).HasColumnName("kind").HasConversion<string>().HasMaxLength(16);
+        builder.Property(entity => entity.RequestHash).HasColumnName("request_hash").HasMaxLength(64).IsRequired();
+        builder.Property(entity => entity.ActorId).HasColumnName("actor_id");
+        builder.Property(entity => entity.State).HasColumnName("state").HasConversion<string>().HasMaxLength(32);
+        builder.Property(entity => entity.IamPrincipalId).HasColumnName("iam_principal_id");
+        builder.Property(entity => entity.IamProfileVersion).HasColumnName("iam_profile_version");
+        builder.Property(entity => entity.IamRoleId).HasColumnName("iam_role_id").HasMaxLength(160);
+        builder.Property(entity => entity.CredentialVersionId).HasColumnName("credential_version_id");
+        builder.Property(entity => entity.CreatedAt).HasColumnName("created_at");
+        builder.Property(entity => entity.UpdatedAt).HasColumnName("updated_at");
+        builder.HasIndex(entity => new { entity.WorkloadId, entity.Kind })
+            .HasDatabaseName("idx_service_identity_operations_workload_kind");
+        builder.Property<uint>("xmin").HasColumnType("xid").IsRowVersion();
+    }
+}

--- a/Maliev.AuthService.Infrastructure/DbContexts/AuthDbContext.cs
+++ b/Maliev.AuthService.Infrastructure/DbContexts/AuthDbContext.cs
@@ -39,6 +39,12 @@ public class AuthDbContext : DbContext
     /// <summary>Gets or sets service credentials.</summary>
     public DbSet<ServiceCredential> ServiceCredentials => Set<ServiceCredential>();
 
+    /// <summary>Gets hashed service credential versions.</summary>
+    public DbSet<ServiceCredentialVersion> ServiceCredentialVersions => Set<ServiceCredentialVersion>();
+
+    /// <summary>Gets durable service identity lifecycle operations.</summary>
+    public DbSet<ServiceIdentityOperation> ServiceIdentityOperations => Set<ServiceIdentityOperation>();
+
     /// <summary>Gets or sets user principals.</summary>
     public DbSet<UserPrincipal> UserPrincipals => Set<UserPrincipal>();
 

--- a/Maliev.AuthService.Infrastructure/HttpClients/WorkloadIdentityIamClient.cs
+++ b/Maliev.AuthService.Infrastructure/HttpClients/WorkloadIdentityIamClient.cs
@@ -1,0 +1,45 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Maliev.AuthService.Application.DTOs.IAM;
+using Maliev.AuthService.Application.Interfaces;
+
+namespace Maliev.AuthService.Infrastructure.HttpClients;
+
+/// <summary>Calls IAM workload provisioning while preserving the employee authorization boundary.</summary>
+public sealed class WorkloadIdentityIamClient(HttpClient httpClient) : IWorkloadIdentityIamClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    /// <inheritdoc/>
+    public async Task<WorkloadPrincipalResponse> ProvisionAsync(
+        string workloadId,
+        ProvisionWorkloadPrincipalRequest request,
+        string callerBearerToken,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(callerBearerToken);
+
+        using var message = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"/iam/v1/workload-principals/{Uri.EscapeDataString(workloadId)}")
+        {
+            Content = JsonContent.Create(request, options: JsonOptions)
+        };
+        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", callerBearerToken);
+
+        using var response = await httpClient.SendAsync(
+            message,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<WorkloadPrincipalResponse>(
+            JsonOptions,
+            cancellationToken)
+            ?? throw new HttpRequestException("IAM returned an empty workload principal response");
+    }
+}

--- a/Maliev.AuthService.Infrastructure/HttpClients/WorkloadIdentityIamEndpoint.cs
+++ b/Maliev.AuthService.Infrastructure/HttpClients/WorkloadIdentityIamEndpoint.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Maliev.AuthService.Infrastructure.HttpClients;
+
+/// <summary>Configures the trusted IAM origin used for employee-authorized workload provisioning.</summary>
+public sealed class WorkloadIdentityIamEndpointOptions
+{
+    /// <summary>Gets or sets an optional explicit canonical IAM origin.</summary>
+    public string? BaseUrl { get; set; }
+}
+
+/// <summary>Resolves and validates the trusted IAM workload-provisioning origin.</summary>
+public interface IWorkloadIdentityIamEndpointResolver
+{
+    /// <summary>Resolves a trusted IAM origin or throws when configuration is unsafe.</summary>
+    Uri Resolve(WorkloadIdentityIamEndpointOptions options);
+}
+
+/// <summary>Environment-aware resolver for the trusted IAM workload-provisioning origin.</summary>
+public sealed class WorkloadIdentityIamEndpointResolver(IHostEnvironment environment)
+    : IWorkloadIdentityIamEndpointResolver
+{
+    /// <inheritdoc/>
+    public Uri Resolve(WorkloadIdentityIamEndpointOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (string.IsNullOrEmpty(options.BaseUrl))
+        {
+            return new Uri(IsLocalEnvironment
+                ? "https+http://IAMService"
+                : "https://IAMService");
+        }
+
+        var value = options.BaseUrl;
+        if (value != value.Trim() ||
+            value.EndsWith("/", StringComparison.Ordinal) ||
+            !Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+            !(uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeHttp) ||
+            !string.IsNullOrEmpty(uri.UserInfo) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment) ||
+            uri.AbsolutePath != "/" ||
+            value != BuildCanonicalOrigin(uri) ||
+            uri.Scheme == Uri.UriSchemeHttp && (!IsLocalEnvironment || !IsExactLoopback(uri.Host)))
+        {
+            throw new OptionsValidationException(
+                nameof(WorkloadIdentityIamEndpointOptions),
+                typeof(WorkloadIdentityIamEndpointOptions),
+                ["Services:IAMService:BaseUrl must be a canonical trusted IAM origin"]);
+        }
+
+        return uri;
+    }
+
+    private bool IsLocalEnvironment =>
+        environment.IsDevelopment() ||
+        string.Equals(environment.EnvironmentName, "Testing", StringComparison.Ordinal);
+
+    private static bool IsExactLoopback(string host) =>
+        string.Equals(host, "localhost", StringComparison.Ordinal) ||
+        IPAddress.TryParse(host.Trim('[', ']'), out var address) && IPAddress.IsLoopback(address);
+
+    private static string BuildCanonicalOrigin(Uri uri)
+    {
+        var host = uri.IdnHost;
+        if (host.Contains(':', StringComparison.Ordinal))
+        {
+            host = $"[{host}]";
+        }
+
+        return uri.IsDefaultPort
+            ? $"{uri.Scheme}://{host}"
+            : $"{uri.Scheme}://{host}:{uri.Port}";
+    }
+}
+
+/// <summary>Registers startup validation and runtime resolution for the trusted IAM origin.</summary>
+public static class WorkloadIdentityIamEndpointExtensions
+{
+    /// <summary>Adds the shared IAM endpoint resolver and fail-fast options validation.</summary>
+    public static IServiceCollection AddWorkloadIdentityIamEndpoint(
+        this IServiceCollection services,
+        IConfigurationSection section,
+        IHostEnvironment environment)
+    {
+        services.AddSingleton<IWorkloadIdentityIamEndpointResolver>(
+            new WorkloadIdentityIamEndpointResolver(environment));
+        services.AddSingleton<IValidateOptions<WorkloadIdentityIamEndpointOptions>,
+            WorkloadIdentityIamEndpointValidator>();
+        services.AddOptions<WorkloadIdentityIamEndpointOptions>()
+            .Bind(section)
+            .ValidateOnStart();
+        return services;
+    }
+
+    private sealed class WorkloadIdentityIamEndpointValidator(
+        IWorkloadIdentityIamEndpointResolver resolver)
+        : IValidateOptions<WorkloadIdentityIamEndpointOptions>
+    {
+        public ValidateOptionsResult Validate(string? name, WorkloadIdentityIamEndpointOptions options)
+        {
+            try
+            {
+                _ = resolver.Resolve(options);
+                return ValidateOptionsResult.Success;
+            }
+            catch (OptionsValidationException exception)
+            {
+                return ValidateOptionsResult.Fail(exception.Failures);
+            }
+        }
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Migrations/20260716002244_AddServiceIdentityLifecycle.Designer.cs
+++ b/Maliev.AuthService.Infrastructure/Migrations/20260716002244_AddServiceIdentityLifecycle.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Maliev.AuthService.Infrastructure.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Maliev.AuthService.Infrastructure.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260716002244_AddServiceIdentityLifecycle")]
+    partial class AddServiceIdentityLifecycle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Maliev.AuthService.Infrastructure/Migrations/20260716002244_AddServiceIdentityLifecycle.cs
+++ b/Maliev.AuthService.Infrastructure/Migrations/20260716002244_AddServiceIdentityLifecycle.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maliev.AuthService.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddServiceIdentityLifecycle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "profile_version",
+                table: "service_credentials",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "revoked_at",
+                table: "service_credentials",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "role_id",
+                table: "service_credentials",
+                type: "character varying(160)",
+                maxLength: 160,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "workload_id",
+                table: "service_credentials",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "service_credential_versions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    service_credential_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    version = table.Column<int>(type: "integer", nullable: false),
+                    secret_hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    status = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    activated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    grace_expires_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    hard_expires_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    revoked_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_service_credential_versions", x => x.id);
+                    table.CheckConstraint("ck_service_credential_versions_expiry", "hard_expires_at > created_at");
+                    table.CheckConstraint("ck_service_credential_versions_hash", "length(secret_hash) = 64 AND secret_hash ~ '^[0-9A-F]{64}$'");
+                    table.CheckConstraint("ck_service_credential_versions_status", "status IN ('Pending', 'Active', 'Grace', 'Revoked')");
+                    table.CheckConstraint("ck_service_credential_versions_version", "version > 0");
+                    table.ForeignKey(
+                        name: "fk_service_credential_versions_service_credentials_service_cre~",
+                        column: x => x.service_credential_id,
+                        principalTable: "service_credentials",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "service_identity_operations",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    workload_id = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    kind = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    request_hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    actor_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    state = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    iam_principal_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    iam_profile_version = table.Column<int>(type: "integer", nullable: true),
+                    iam_role_id = table.Column<string>(type: "character varying(160)", maxLength: 160, nullable: true),
+                    credential_version_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_service_identity_operations", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_service_credentials_workload_id",
+                table: "service_credentials",
+                column: "workload_id",
+                unique: true,
+                filter: "workload_id IS NOT NULL");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_service_credentials_managed_binding",
+                table: "service_credentials",
+                sql: "workload_id IS NULL OR (principal_id IS NOT NULL AND profile_version IS NOT NULL AND profile_version > 0 AND role_id IS NOT NULL)");
+
+            migrationBuilder.CreateIndex(
+                name: "idx_service_credential_versions_credential_status",
+                table: "service_credential_versions",
+                columns: new[] { "service_credential_id", "status" });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_service_credential_versions_credential_version",
+                table: "service_credential_versions",
+                columns: new[] { "service_credential_id", "version" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_service_credential_versions_one_active",
+                table: "service_credential_versions",
+                column: "service_credential_id",
+                unique: true,
+                filter: "status = 'Active'");
+
+            migrationBuilder.CreateIndex(
+                name: "idx_service_identity_operations_workload_kind",
+                table: "service_identity_operations",
+                columns: new[] { "workload_id", "kind" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "service_credential_versions");
+
+            migrationBuilder.DropTable(
+                name: "service_identity_operations");
+
+            migrationBuilder.DropIndex(
+                name: "idx_service_credentials_workload_id",
+                table: "service_credentials");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_service_credentials_managed_binding",
+                table: "service_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "profile_version",
+                table: "service_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "revoked_at",
+                table: "service_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "role_id",
+                table: "service_credentials");
+
+            migrationBuilder.DropColumn(
+                name: "workload_id",
+                table: "service_credentials");
+        }
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Services/AuthenticationService.cs
+++ b/Maliev.AuthService.Infrastructure/Services/AuthenticationService.cs
@@ -411,21 +411,16 @@ public class AuthenticationService : IAuthenticationService
     {
         var serviceCredential = await _dbContext.ServiceCredentials
             .AsNoTracking()
+            .Include(sc => sc.Versions)
             .FirstOrDefaultAsync(
                 sc => sc.ClientId == request.ClientId,
                 cancellationToken);
 
         var suppliedSecretHash = SHA256.HashData(Encoding.UTF8.GetBytes(request.ClientSecret));
-        var expectedSecretHash = DummyServiceSecretHash;
-        if (serviceCredential is { IsActive: true } &&
-            TryDecodeSha256(serviceCredential.ClientSecretHash, out var decodedSecretHash))
-        {
-            expectedSecretHash = decodedSecretHash;
-        }
-
-        var credentialMatches = CryptographicOperations.FixedTimeEquals(
+        var credentialMatches = MatchesServiceCredential(
+            serviceCredential,
             suppliedSecretHash,
-            expectedSecretHash);
+            DateTimeOffset.UtcNow);
         if (serviceCredential is not { IsActive: true } || !credentialMatches)
         {
             EnqueueAuditLog(null, null, "service_login", ipAddress, false, "Invalid client credentials");
@@ -510,6 +505,38 @@ public class AuthenticationService : IAuthenticationService
                 }
             }
         };
+    }
+
+    private static bool MatchesServiceCredential(
+        ServiceCredential? credential,
+        ReadOnlySpan<byte> suppliedSecretHash,
+        DateTimeOffset now)
+    {
+        if (credential is not { IsActive: true } || credential.RevokedAt.HasValue)
+        {
+            _ = CryptographicOperations.FixedTimeEquals(suppliedSecretHash, DummyServiceSecretHash);
+            return false;
+        }
+
+        if (credential.Versions.Count == 0)
+        {
+            var expected = TryDecodeSha256(credential.ClientSecretHash, out var legacyHash)
+                ? legacyHash
+                : DummyServiceSecretHash;
+            return CryptographicOperations.FixedTimeEquals(suppliedSecretHash, expected);
+        }
+
+        var matched = false;
+        foreach (var version in credential.Versions)
+        {
+            var expected = TryDecodeSha256(version.SecretHash, out var versionHash)
+                ? versionHash
+                : DummyServiceSecretHash;
+            var hashMatches = CryptographicOperations.FixedTimeEquals(suppliedSecretHash, expected);
+            matched |= hashMatches && version.CanAuthenticate(now);
+        }
+
+        return matched;
     }
 
     private static bool TryDecodeSha256(string value, out byte[] hash)

--- a/Maliev.AuthService.Infrastructure/Services/ServiceIdentityIamContract.cs
+++ b/Maliev.AuthService.Infrastructure/Services/ServiceIdentityIamContract.cs
@@ -1,0 +1,28 @@
+namespace Maliev.AuthService.Infrastructure.Services;
+
+/// <summary>Defines AuthService's exact contract with IAM workload provisioning.</summary>
+public static class ServiceIdentityIamContract
+{
+    /// <summary>Validates and returns a canonical IAM workload identifier.</summary>
+    public static string ValidateWorkloadId(string workloadId)
+    {
+        if (workloadId is not { Length: > 0 and <= 100 } ||
+            workloadId[0] == '-' || workloadId[^1] == '-' ||
+            workloadId.Contains("--", StringComparison.Ordinal) ||
+            workloadId.Any(character => character is not (
+                >= 'a' and <= 'z' or >= '0' and <= '9' or '-')))
+        {
+            throw new ArgumentException("Workload identifier is not canonical", nameof(workloadId));
+        }
+
+        return workloadId;
+    }
+
+    /// <summary>Returns the deterministic role identifier IAM must bind for a workload profile.</summary>
+    public static string ExpectedRoleId(string workloadId, int profileVersion)
+    {
+        workloadId = ValidateWorkloadId(workloadId);
+        ArgumentOutOfRangeException.ThrowIfLessThan(profileVersion, 1);
+        return $"roles.workloads.{workloadId}.v{profileVersion}";
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Services/ServiceIdentityManager.cs
+++ b/Maliev.AuthService.Infrastructure/Services/ServiceIdentityManager.cs
@@ -1,0 +1,564 @@
+using System.Data;
+using System.Security.Cryptography;
+using System.Text;
+using Maliev.AuthService.Application.DTOs.IAM;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Application.DTOs.Response;
+using Maliev.AuthService.Application.Interfaces;
+using Maliev.AuthService.Domain.Entities;
+using Maliev.AuthService.Infrastructure.DbContexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace Maliev.AuthService.Infrastructure.Services;
+
+/// <summary>Coordinates IAM-backed service identity credential lifecycle operations.</summary>
+public sealed class ServiceIdentityManager(
+    AuthDbContext dbContext,
+    IWorkloadIdentityIamClient iamClient,
+    TimeProvider timeProvider) : IServiceIdentityManager
+{
+    /// <inheritdoc/>
+    public async Task<ServiceIdentityResponse> ProvisionAsync(
+        string workloadId,
+        ProvisionServiceIdentityRequest request,
+        Guid actorId,
+        string callerBearerToken,
+        CancellationToken cancellationToken = default)
+    {
+        workloadId = ValidateWorkloadId(workloadId);
+        ValidateActorAndOperation(actorId, request.OperationId);
+        var requestHash = HashCanonicalRequest(
+            $"provision|{workloadId}|{request.ProfileVersion}|{request.ServiceName}|{request.HardExpiryDays}");
+
+        return await WithWorkloadLockAsync(workloadId, async () =>
+        {
+            var operation = await GetOrStartOperationAsync(
+                request.OperationId,
+                workloadId,
+                ServiceIdentityOperationKind.Provision,
+                requestHash,
+                actorId,
+                cancellationToken);
+
+            if (operation.State == ServiceIdentityOperationState.Completed)
+            {
+                return await GetRequiredResponseAsync(workloadId, secret: null, cancellationToken);
+            }
+
+            if (operation.State == ServiceIdentityOperationState.Started)
+            {
+                var iamResponse = await iamClient.ProvisionAsync(
+                    workloadId,
+                    new ProvisionWorkloadPrincipalRequest
+                    {
+                        ProfileVersion = request.ProfileVersion,
+                        OperationId = request.OperationId
+                    },
+                    callerBearerToken,
+                    cancellationToken);
+                ValidateIamResponse(workloadId, request.ProfileVersion, iamResponse);
+                operation.IamPrincipalId = iamResponse.PrincipalId;
+                operation.IamProfileVersion = iamResponse.ProfileVersion;
+                operation.IamRoleId = iamResponse.RoleId;
+                operation.State = ServiceIdentityOperationState.IamReady;
+                operation.UpdatedAt = UtcNow;
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            if (operation.State == ServiceIdentityOperationState.CredentialCommitted)
+            {
+                await CompleteAsync(operation, cancellationToken);
+                return await GetRequiredResponseAsync(workloadId, secret: null, cancellationToken);
+            }
+
+            var existing = await dbContext.ServiceCredentials
+                .AsNoTracking()
+                .Include(item => item.Versions)
+                .SingleOrDefaultAsync(credential => credential.WorkloadId == workloadId, cancellationToken);
+            if (existing is not null)
+            {
+                EnsureExactBinding(existing, operation);
+                EnsureProvisionMatches(existing, request);
+                operation.State = ServiceIdentityOperationState.CredentialCommitted;
+                operation.UpdatedAt = UtcNow;
+                await dbContext.SaveChangesAsync(cancellationToken);
+                await CompleteAsync(operation, cancellationToken);
+                return await GetRequiredResponseAsync(workloadId, secret: null, cancellationToken);
+            }
+
+            var generatedSecret = GenerateSecret();
+            var secretHash = HashSecret(generatedSecret);
+            var now = UtcNow;
+            var credential = new ServiceCredential
+            {
+                Id = Guid.NewGuid(),
+                ClientId = $"service-{workloadId}",
+                PrincipalId = operation.IamPrincipalId,
+                WorkloadId = workloadId,
+                ProfileVersion = operation.IamProfileVersion,
+                RoleId = operation.IamRoleId,
+                ClientSecretHash = secretHash,
+                ServiceName = request.ServiceName.Trim(),
+                IsActive = true,
+                CreatedAt = now.UtcDateTime,
+                UpdatedAt = now.UtcDateTime
+            };
+            var version = new ServiceCredentialVersion
+            {
+                Id = Guid.NewGuid(),
+                ServiceCredentialId = credential.Id,
+                Version = 1,
+                SecretHash = secretHash,
+                Status = ServiceCredentialVersionStatus.Active,
+                CreatedAt = now,
+                ActivatedAt = now,
+                HardExpiresAt = now.AddDays(request.HardExpiryDays)
+            };
+
+            await using (var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken))
+            {
+                dbContext.ServiceCredentials.Add(credential);
+                dbContext.ServiceCredentialVersions.Add(version);
+                AddAudit(actorId, "service_identity_provision", request.OperationId);
+                operation.CredentialVersionId = version.Id;
+                operation.State = ServiceIdentityOperationState.CredentialCommitted;
+                operation.UpdatedAt = now;
+                await dbContext.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+            }
+
+            await CompleteAsync(operation, cancellationToken);
+            return BuildResponse(credential, version, generatedSecret);
+        }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<ServiceIdentityResponse?> GetAsync(
+        string workloadId,
+        CancellationToken cancellationToken = default)
+    {
+        workloadId = ValidateWorkloadId(workloadId);
+        var credential = await dbContext.ServiceCredentials
+            .AsNoTracking()
+            .Include(entity => entity.Versions)
+            .SingleOrDefaultAsync(entity => entity.WorkloadId == workloadId, cancellationToken);
+        if (credential is null)
+        {
+            return null;
+        }
+
+        var version = credential.Versions
+            .OrderByDescending(item => item.Version)
+            .FirstOrDefault()
+            ?? throw new ServiceIdentityConflictException("Managed identity has no credential version");
+        return BuildResponse(credential, version, secret: null);
+    }
+
+    /// <inheritdoc/>
+    public async Task<ServiceIdentityResponse> RotateAsync(
+        string workloadId,
+        RotateServiceIdentityRequest request,
+        Guid actorId,
+        CancellationToken cancellationToken = default)
+    {
+        workloadId = ValidateWorkloadId(workloadId);
+        ValidateActorAndOperation(actorId, request.OperationId);
+        var requestHash = HashCanonicalRequest(
+            $"rotate|{workloadId}|{request.GracePeriodSeconds}|{request.HardExpiryDays}");
+
+        return await WithWorkloadLockAsync(workloadId, async () =>
+        {
+            var operation = await GetOrStartOperationAsync(
+                request.OperationId,
+                workloadId,
+                ServiceIdentityOperationKind.Rotate,
+                requestHash,
+                actorId,
+                cancellationToken);
+            if (operation.State is ServiceIdentityOperationState.Completed or ServiceIdentityOperationState.CredentialCommitted)
+            {
+                if (operation.State == ServiceIdentityOperationState.CredentialCommitted)
+                {
+                    await CompleteAsync(operation, cancellationToken);
+                }
+
+                return await GetRequiredResponseAsync(workloadId, secret: null, cancellationToken);
+            }
+
+            var credential = await dbContext.ServiceCredentials
+                .Include(entity => entity.Versions)
+                .SingleOrDefaultAsync(entity => entity.WorkloadId == workloadId, cancellationToken)
+                ?? throw new ServiceIdentityNotFoundException();
+            EnsureManagedActive(credential);
+
+            if (operation.State == ServiceIdentityOperationState.Started)
+            {
+                operation.IamPrincipalId = credential.PrincipalId;
+                operation.IamProfileVersion = credential.ProfileVersion;
+                operation.IamRoleId = credential.RoleId;
+                operation.State = ServiceIdentityOperationState.IamReady;
+                operation.UpdatedAt = UtcNow;
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            var generatedSecret = GenerateSecret();
+            var now = UtcNow;
+            var version = new ServiceCredentialVersion
+            {
+                Id = Guid.NewGuid(),
+                ServiceCredentialId = credential.Id,
+                Version = credential.Versions.Select(item => item.Version).DefaultIfEmpty().Max() + 1,
+                SecretHash = HashSecret(generatedSecret),
+                Status = ServiceCredentialVersionStatus.Active,
+                CreatedAt = now,
+                ActivatedAt = now,
+                HardExpiresAt = now.AddDays(request.HardExpiryDays)
+            };
+            credential.ClientSecretHash = version.SecretHash;
+            credential.UpdatedAt = now.UtcDateTime;
+            foreach (var trackedVersion in credential.Versions)
+            {
+                dbContext.Entry(trackedVersion).State = EntityState.Detached;
+            }
+
+            await using (var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken))
+            {
+                if (request.GracePeriodSeconds == 0)
+                {
+                    await dbContext.ServiceCredentialVersions
+                        .Where(item =>
+                            item.ServiceCredentialId == credential.Id &&
+                            (item.Status == ServiceCredentialVersionStatus.Active ||
+                                item.Status == ServiceCredentialVersionStatus.Grace))
+                        .ExecuteUpdateAsync(setters => setters
+                            .SetProperty(item => item.Status, ServiceCredentialVersionStatus.Revoked)
+                            .SetProperty(item => item.RevokedAt, now), cancellationToken);
+                }
+                else
+                {
+                    await dbContext.ServiceCredentialVersions
+                        .Where(item =>
+                            item.ServiceCredentialId == credential.Id &&
+                            item.Status == ServiceCredentialVersionStatus.Grace)
+                        .ExecuteUpdateAsync(setters => setters
+                            .SetProperty(item => item.Status, ServiceCredentialVersionStatus.Revoked)
+                            .SetProperty(item => item.RevokedAt, now), cancellationToken);
+                    var graceExpiresAt = now.AddSeconds(request.GracePeriodSeconds);
+                    await dbContext.ServiceCredentialVersions
+                        .Where(item =>
+                            item.ServiceCredentialId == credential.Id &&
+                            item.Status == ServiceCredentialVersionStatus.Active)
+                        .ExecuteUpdateAsync(setters => setters
+                            .SetProperty(item => item.Status, ServiceCredentialVersionStatus.Grace)
+                            .SetProperty(item => item.GraceExpiresAt, graceExpiresAt), cancellationToken);
+                }
+
+                dbContext.ServiceCredentialVersions.Add(version);
+                AddAudit(actorId, "service_identity_rotate", request.OperationId);
+                operation.CredentialVersionId = version.Id;
+                operation.State = ServiceIdentityOperationState.CredentialCommitted;
+                operation.UpdatedAt = now;
+                await dbContext.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+            }
+
+            await CompleteAsync(operation, cancellationToken);
+            return BuildResponse(credential, version, generatedSecret);
+        }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task RevokeAsync(
+        string workloadId,
+        RevokeServiceIdentityRequest request,
+        Guid actorId,
+        CancellationToken cancellationToken = default)
+    {
+        workloadId = ValidateWorkloadId(workloadId);
+        ValidateActorAndOperation(actorId, request.OperationId);
+        var requestHash = HashCanonicalRequest($"revoke|{workloadId}");
+
+        await WithWorkloadLockAsync(workloadId, async () =>
+        {
+            var operation = await GetOrStartOperationAsync(
+                request.OperationId,
+                workloadId,
+                ServiceIdentityOperationKind.Revoke,
+                requestHash,
+                actorId,
+                cancellationToken);
+            if (operation.State == ServiceIdentityOperationState.Completed)
+            {
+                return true;
+            }
+
+            if (operation.State == ServiceIdentityOperationState.CredentialCommitted)
+            {
+                await CompleteAsync(operation, cancellationToken);
+                return true;
+            }
+
+            var credential = await dbContext.ServiceCredentials
+                .Include(entity => entity.Versions)
+                .SingleOrDefaultAsync(entity => entity.WorkloadId == workloadId, cancellationToken)
+                ?? throw new ServiceIdentityNotFoundException();
+            var now = UtcNow;
+            operation.IamPrincipalId ??= credential.PrincipalId;
+            operation.IamProfileVersion ??= credential.ProfileVersion;
+            operation.IamRoleId ??= credential.RoleId;
+            operation.State = ServiceIdentityOperationState.IamReady;
+            credential.IsActive = false;
+            credential.ClientSecretHash = HashSecret(GenerateSecret());
+            credential.RevokedAt = now;
+            credential.UpdatedAt = now.UtcDateTime;
+            foreach (var trackedVersion in credential.Versions)
+            {
+                dbContext.Entry(trackedVersion).State = EntityState.Detached;
+            }
+
+            await using (var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken))
+            {
+                await dbContext.ServiceCredentialVersions
+                    .Where(item =>
+                        item.ServiceCredentialId == credential.Id &&
+                        item.Status != ServiceCredentialVersionStatus.Revoked)
+                    .ExecuteUpdateAsync(setters => setters
+                        .SetProperty(item => item.Status, ServiceCredentialVersionStatus.Revoked)
+                        .SetProperty(item => item.RevokedAt, now), cancellationToken);
+                AddAudit(actorId, "service_identity_revoke", request.OperationId);
+                operation.State = ServiceIdentityOperationState.CredentialCommitted;
+                operation.UpdatedAt = now;
+                await dbContext.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+            }
+
+            await CompleteAsync(operation, cancellationToken);
+            return true;
+        }, cancellationToken);
+    }
+
+    private DateTimeOffset UtcNow => timeProvider.GetUtcNow();
+
+    private async Task<ServiceIdentityOperation> GetOrStartOperationAsync(
+        Guid operationId,
+        string workloadId,
+        ServiceIdentityOperationKind kind,
+        string requestHash,
+        Guid actorId,
+        CancellationToken cancellationToken)
+    {
+        var operation = await dbContext.ServiceIdentityOperations
+            .SingleOrDefaultAsync(item => item.Id == operationId, cancellationToken);
+        if (operation is not null)
+        {
+            if (operation.WorkloadId != workloadId ||
+                operation.Kind != kind ||
+                operation.RequestHash != requestHash ||
+                operation.ActorId != actorId)
+            {
+                throw new ServiceIdentityConflictException(
+                    "Operation identifier is already bound to another actor or request");
+            }
+
+            return operation;
+        }
+
+        var now = UtcNow;
+        operation = new ServiceIdentityOperation
+        {
+            Id = operationId,
+            WorkloadId = workloadId,
+            Kind = kind,
+            RequestHash = requestHash,
+            ActorId = actorId,
+            State = ServiceIdentityOperationState.Started,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        dbContext.ServiceIdentityOperations.Add(operation);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return operation;
+    }
+
+    private async Task CompleteAsync(
+        ServiceIdentityOperation operation,
+        CancellationToken cancellationToken)
+    {
+        operation.State = ServiceIdentityOperationState.Completed;
+        operation.UpdatedAt = UtcNow;
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<ServiceIdentityResponse> GetRequiredResponseAsync(
+        string workloadId,
+        string? secret,
+        CancellationToken cancellationToken) =>
+        await GetAsync(workloadId, cancellationToken)
+        ?? throw new ServiceIdentityConflictException("Completed operation has no credential");
+
+    private void AddAudit(Guid actorId, string action, Guid operationId)
+    {
+        dbContext.AuthAuditLogs.Add(new AuthAuditLog
+        {
+            Id = Guid.NewGuid(),
+            UserId = actorId,
+            UserType = UserType.Employee,
+            Action = action,
+            IpAddress = string.Empty,
+            Success = true,
+            CorrelationId = operationId.ToString("D"),
+            CreatedAt = UtcNow.UtcDateTime
+        });
+    }
+
+    private static void ValidateIamResponse(
+        string workloadId,
+        int profileVersion,
+        WorkloadPrincipalResponse response)
+    {
+        if (response.WorkloadId != workloadId ||
+            response.PrincipalId == Guid.Empty ||
+            response.ProfileVersion != profileVersion ||
+            !IsCanonicalRole(response.RoleId) ||
+            response.RoleId.Contains("platform.owner", StringComparison.Ordinal))
+        {
+            throw new ServiceIdentityConflictException("IAM returned a mismatched or unsafe workload binding");
+        }
+    }
+
+    private static void EnsureExactBinding(
+        ServiceCredential credential,
+        ServiceIdentityOperation operation)
+    {
+        if (credential.PrincipalId != operation.IamPrincipalId ||
+            credential.ProfileVersion != operation.IamProfileVersion ||
+            credential.RoleId != operation.IamRoleId)
+        {
+            throw new ServiceIdentityConflictException("Existing service identity has another IAM binding");
+        }
+    }
+
+    private static void EnsureManagedActive(ServiceCredential credential)
+    {
+        if (!credential.IsActive || credential.RevokedAt.HasValue ||
+            !credential.PrincipalId.HasValue || credential.PrincipalId == Guid.Empty ||
+            !credential.ProfileVersion.HasValue || string.IsNullOrWhiteSpace(credential.RoleId))
+        {
+            throw new ServiceIdentityConflictException("Service identity is not an active managed identity");
+        }
+    }
+
+    private static void EnsureProvisionMatches(
+        ServiceCredential credential,
+        ProvisionServiceIdentityRequest request)
+    {
+        var latest = credential.Versions.OrderByDescending(item => item.Version).FirstOrDefault()
+            ?? throw new ServiceIdentityConflictException("Existing service identity has no credential version");
+        var configuredLifetime = latest.HardExpiresAt - latest.CreatedAt;
+        if (credential.ServiceName != request.ServiceName.Trim() ||
+            configuredLifetime != TimeSpan.FromDays(request.HardExpiryDays))
+        {
+            throw new ServiceIdentityConflictException(
+                "Existing service identity does not match the requested lifecycle parameters");
+        }
+    }
+
+    private static ServiceIdentityResponse BuildResponse(
+        ServiceCredential credential,
+        ServiceCredentialVersion version,
+        string? secret) => new()
+        {
+            WorkloadId = credential.WorkloadId
+                ?? throw new ServiceIdentityConflictException("Credential is not workload managed"),
+            ClientId = credential.ClientId,
+            PrincipalId = credential.PrincipalId
+                ?? throw new ServiceIdentityConflictException("Credential has no IAM principal"),
+            ProfileVersion = credential.ProfileVersion
+                ?? throw new ServiceIdentityConflictException("Credential has no IAM profile"),
+            RoleId = credential.RoleId
+                ?? throw new ServiceIdentityConflictException("Credential has no IAM role"),
+            IsActive = credential.IsActive,
+            CredentialVersion = version.Version,
+            ClientSecret = secret,
+            SecretRetrievable = secret is not null,
+            HardExpiresAt = version.HardExpiresAt
+        };
+
+    private static string ValidateWorkloadId(string workloadId)
+    {
+        if (workloadId is not { Length: > 0 and <= 80 } ||
+            workloadId != workloadId.Trim().ToLowerInvariant() ||
+            workloadId[0] is not (>= 'a' and <= 'z') ||
+            workloadId.Any(character => character is not (
+                >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '.')))
+        {
+            throw new ArgumentException("Workload identifier is not canonical", nameof(workloadId));
+        }
+
+        return workloadId;
+    }
+
+    private static void ValidateActorAndOperation(Guid actorId, Guid operationId)
+    {
+        ArgumentOutOfRangeException.ThrowIfEqual(actorId, Guid.Empty);
+        ArgumentOutOfRangeException.ThrowIfEqual(operationId, Guid.Empty);
+    }
+
+    private static bool IsCanonicalRole(string value) =>
+        value is { Length: > 0 and <= 160 } &&
+        value == value.Trim().ToLowerInvariant() &&
+        value != "*" &&
+        !value.Contains('*') &&
+        value.All(character => character is
+            >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '_' or '.' or '/');
+
+    private static string GenerateSecret()
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    private static string HashSecret(string secret) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(secret)));
+
+    private static string HashCanonicalRequest(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+    private async Task<T> WithWorkloadLockAsync<T>(
+        string workloadId,
+        Func<Task<T>> action,
+        CancellationToken cancellationToken)
+    {
+        var connection = dbContext.Database.GetDbConnection();
+        var closeConnection = connection.State == ConnectionState.Closed;
+        if (closeConnection)
+        {
+            await dbContext.Database.OpenConnectionAsync(cancellationToken);
+        }
+
+        await dbContext.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT pg_advisory_lock(hashtextextended({workloadId}, 0));",
+            cancellationToken);
+        try
+        {
+            return await action();
+        }
+        finally
+        {
+            await dbContext.Database.ExecuteSqlInterpolatedAsync(
+                $"SELECT pg_advisory_unlock(hashtextextended({workloadId}, 0));",
+                CancellationToken.None);
+            if (closeConnection)
+            {
+                await dbContext.Database.CloseConnectionAsync();
+            }
+        }
+    }
+}
+
+/// <summary>Signals an idempotency or authoritative binding conflict.</summary>
+public sealed class ServiceIdentityConflictException(string message) : InvalidOperationException(message);
+
+/// <summary>Signals that a managed service identity was not found.</summary>
+public sealed class ServiceIdentityNotFoundException : KeyNotFoundException;

--- a/Maliev.AuthService.Infrastructure/Services/ServiceIdentityManager.cs
+++ b/Maliev.AuthService.Infrastructure/Services/ServiceIdentityManager.cs
@@ -25,7 +25,7 @@ public sealed class ServiceIdentityManager(
         string callerBearerToken,
         CancellationToken cancellationToken = default)
     {
-        workloadId = ValidateWorkloadId(workloadId);
+        workloadId = ServiceIdentityIamContract.ValidateWorkloadId(workloadId);
         ValidateActorAndOperation(actorId, request.OperationId);
         var requestHash = HashCanonicalRequest(
             $"provision|{workloadId}|{request.ProfileVersion}|{request.ServiceName}|{request.HardExpiryDays}");
@@ -137,7 +137,7 @@ public sealed class ServiceIdentityManager(
         string workloadId,
         CancellationToken cancellationToken = default)
     {
-        workloadId = ValidateWorkloadId(workloadId);
+        workloadId = ServiceIdentityIamContract.ValidateWorkloadId(workloadId);
         var credential = await dbContext.ServiceCredentials
             .AsNoTracking()
             .Include(entity => entity.Versions)
@@ -161,7 +161,7 @@ public sealed class ServiceIdentityManager(
         Guid actorId,
         CancellationToken cancellationToken = default)
     {
-        workloadId = ValidateWorkloadId(workloadId);
+        workloadId = ServiceIdentityIamContract.ValidateWorkloadId(workloadId);
         ValidateActorAndOperation(actorId, request.OperationId);
         var requestHash = HashCanonicalRequest(
             $"rotate|{workloadId}|{request.GracePeriodSeconds}|{request.HardExpiryDays}");
@@ -274,7 +274,7 @@ public sealed class ServiceIdentityManager(
         Guid actorId,
         CancellationToken cancellationToken = default)
     {
-        workloadId = ValidateWorkloadId(workloadId);
+        workloadId = ServiceIdentityIamContract.ValidateWorkloadId(workloadId);
         ValidateActorAndOperation(actorId, request.OperationId);
         var requestHash = HashCanonicalRequest($"revoke|{workloadId}");
 
@@ -419,8 +419,7 @@ public sealed class ServiceIdentityManager(
         if (response.WorkloadId != workloadId ||
             response.PrincipalId == Guid.Empty ||
             response.ProfileVersion != profileVersion ||
-            !IsCanonicalRole(response.RoleId) ||
-            response.RoleId.Contains("platform.owner", StringComparison.Ordinal))
+            response.RoleId != ServiceIdentityIamContract.ExpectedRoleId(workloadId, profileVersion))
         {
             throw new ServiceIdentityConflictException("IAM returned a mismatched or unsafe workload binding");
         }
@@ -484,33 +483,11 @@ public sealed class ServiceIdentityManager(
             HardExpiresAt = version.HardExpiresAt
         };
 
-    private static string ValidateWorkloadId(string workloadId)
-    {
-        if (workloadId is not { Length: > 0 and <= 80 } ||
-            workloadId != workloadId.Trim().ToLowerInvariant() ||
-            workloadId[0] is not (>= 'a' and <= 'z') ||
-            workloadId.Any(character => character is not (
-                >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '.')))
-        {
-            throw new ArgumentException("Workload identifier is not canonical", nameof(workloadId));
-        }
-
-        return workloadId;
-    }
-
     private static void ValidateActorAndOperation(Guid actorId, Guid operationId)
     {
         ArgumentOutOfRangeException.ThrowIfEqual(actorId, Guid.Empty);
         ArgumentOutOfRangeException.ThrowIfEqual(operationId, Guid.Empty);
     }
-
-    private static bool IsCanonicalRole(string value) =>
-        value is { Length: > 0 and <= 160 } &&
-        value == value.Trim().ToLowerInvariant() &&
-        value != "*" &&
-        !value.Contains('*') &&
-        value.All(character => character is
-            >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '_' or '.' or '/');
 
     private static string GenerateSecret()
     {

--- a/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Domain.Entities;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Contract;
+
+[Collection("AuthService Collection")]
+public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory factory) : IAsyncLifetime
+{
+    public Task InitializeAsync() => factory.CleanDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ServiceLogin_ActiveAndUnexpiredGraceVersions_BothAuthenticate()
+    {
+        const string activeSecret = "active-secret-with-at-least-32-random-looking-bytes";
+        const string graceSecret = "grace-secret-with-at-least-32-random-looking-bytes";
+        await SeedManagedCredentialAsync(
+            true,
+            (activeSecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null),
+            (graceSecret, ServiceCredentialVersionStatus.Grace, DateTimeOffset.UtcNow.AddHours(1), DateTimeOffset.UtcNow.AddMinutes(5)));
+        using var client = factory.CreateClient();
+
+        var active = await LoginAsync(client, activeSecret, "127.0.10.1");
+        var grace = await LoginAsync(client, graceSecret, "127.0.10.2");
+
+        Assert.Equal(HttpStatusCode.OK, active.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, grace.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(ServiceCredentialVersionStatus.Pending, true)]
+    [InlineData(ServiceCredentialVersionStatus.Revoked, true)]
+    [InlineData(ServiceCredentialVersionStatus.Active, false)]
+    public async Task ServiceLogin_IneligibleVersionOrLogicalRevoke_IsUnauthorized(
+        ServiceCredentialVersionStatus status,
+        bool logicalActive)
+    {
+        const string secret = "ineligible-secret-with-at-least-32-random-looking-bytes";
+        await SeedManagedCredentialAsync(
+            logicalActive,
+            (secret, status, DateTimeOffset.UtcNow.AddHours(1), null));
+        using var client = factory.CreateClient();
+
+        var response = await LoginAsync(client, secret, "127.0.11.1");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ServiceLogin_ExpiredActiveVersion_IsUnauthorized()
+    {
+        const string secret = "expired-secret-with-at-least-32-random-looking-bytes";
+        await SeedManagedCredentialAsync(
+            true,
+            (secret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddSeconds(-1), null));
+        using var client = factory.CreateClient();
+
+        var response = await LoginAsync(client, secret, "127.0.12.1");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private static async Task<HttpResponseMessage> LoginAsync(
+        HttpClient client,
+        string secret,
+        string ipAddress)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/auth/v1/service/login")
+        {
+            Content = JsonContent.Create(
+                new ServiceLoginRequest
+                {
+                    ClientId = "service-auth-managed",
+                    ClientSecret = secret
+                },
+                options: new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+                })
+        };
+        request.Headers.Add("X-Test-Client-IP", ipAddress);
+        return await client.SendAsync(request);
+    }
+
+    private async Task SeedManagedCredentialAsync(
+        bool logicalActive,
+        params (string Secret, ServiceCredentialVersionStatus Status, DateTimeOffset HardExpiry, DateTimeOffset? GraceExpiry)[] versions)
+    {
+        await using var context = factory.CreateDbContext();
+        var now = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var credential = new ServiceCredential
+        {
+            Id = Guid.NewGuid(),
+            ClientId = "service-auth-managed",
+            PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            WorkloadId = "auth",
+            ProfileVersion = 1,
+            RoleId = "roles.workload.auth",
+            ClientSecretHash = Hash(versions[0].Secret),
+            ServiceName = "Auth Service",
+            IsActive = logicalActive,
+            RevokedAt = logicalActive ? null : DateTimeOffset.UtcNow,
+            CreatedAt = now.UtcDateTime,
+            UpdatedAt = now.UtcDateTime
+        };
+        context.ServiceCredentials.Add(credential);
+        for (var index = 0; index < versions.Length; index++)
+        {
+            var version = versions[index];
+            context.ServiceCredentialVersions.Add(new ServiceCredentialVersion
+            {
+                Id = Guid.NewGuid(),
+                ServiceCredentialId = credential.Id,
+                Version = index + 1,
+                SecretHash = Hash(version.Secret),
+                Status = version.Status,
+                CreatedAt = now,
+                ActivatedAt = version.Status is ServiceCredentialVersionStatus.Active or ServiceCredentialVersionStatus.Grace
+                    ? now
+                    : null,
+                GraceExpiresAt = version.GraceExpiry,
+                HardExpiresAt = version.HardExpiry,
+                RevokedAt = version.Status == ServiceCredentialVersionStatus.Revoked
+                    ? DateTimeOffset.UtcNow
+                    : null
+            });
+        }
+
+        await context.SaveChangesAsync();
+    }
+
+    private static string Hash(string secret) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(secret)));
+}

--- a/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
@@ -77,7 +77,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             Content = JsonContent.Create(
                 new ServiceLoginRequest
                 {
-                    ClientId = "service-auth-managed",
+                    ClientId = "service-auth-service",
                     ClientSecret = secret
                 },
                 options: new JsonSerializerOptions
@@ -98,11 +98,11 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         var credential = new ServiceCredential
         {
             Id = Guid.NewGuid(),
-            ClientId = "service-auth-managed",
+            ClientId = "service-auth-service",
             PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
-            WorkloadId = "auth",
+            WorkloadId = "auth-service",
             ProfileVersion = 1,
-            RoleId = "roles.workload.auth",
+            RoleId = "roles.workloads.auth-service.v1",
             ClientSecretHash = Hash(versions[0].Secret),
             ServiceName = "Auth Service",
             IsActive = logicalActive,

--- a/Maliev.AuthService.Tests/Integration/ServiceIdentityManagerTests.cs
+++ b/Maliev.AuthService.Tests/Integration/ServiceIdentityManagerTests.cs
@@ -1,0 +1,340 @@
+using Maliev.AuthService.Application.DTOs.IAM;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Application.Interfaces;
+using Maliev.AuthService.Domain.Entities;
+using Maliev.AuthService.Infrastructure.Services;
+using Maliev.AuthService.Tests.Contract;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Integration;
+
+[Collection("AuthService Collection")]
+public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factory) : IAsyncLifetime
+{
+    private static readonly Guid ActorId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    public Task InitializeAsync() => factory.CleanDatabaseAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ProvisionAsync_SameOperationReplay_ReturnsSecretOnceAndCallsIamOnce()
+    {
+        await using var context = factory.CreateDbContext();
+        var iam = new RecordingIamClient();
+        var manager = new ServiceIdentityManager(context, iam, TimeProvider.System);
+        var request = NewProvisionRequest();
+
+        var created = await manager.ProvisionAsync("auth", request, ActorId, "employee-token");
+        context.ChangeTracker.Clear();
+        var replay = await manager.ProvisionAsync("auth", request, ActorId, "employee-token");
+
+        Assert.True(created.SecretRetrievable);
+        Assert.NotNull(created.ClientSecret);
+        Assert.True(created.ClientSecret.Length >= 43);
+        Assert.False(replay.SecretRetrievable);
+        Assert.Null(replay.ClientSecret);
+        Assert.Equal(1, iam.CallCount);
+        Assert.Equal("employee-token", iam.LastBearerToken);
+
+        var persisted = await context.ServiceCredentialVersions.AsNoTracking().SingleAsync();
+        Assert.NotEqual(created.ClientSecret, persisted.SecretHash);
+        Assert.Equal(64, persisted.SecretHash.Length);
+        Assert.DoesNotContain(created.ClientSecret, await DumpStringColumnsAsync(context));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_ReusedOperationFromAnotherActor_Conflicts()
+    {
+        await using var context = factory.CreateDbContext();
+        var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
+        var request = NewProvisionRequest();
+        _ = await manager.ProvisionAsync("auth", request, ActorId, "employee-token");
+        context.ChangeTracker.Clear();
+
+        await Assert.ThrowsAsync<ServiceIdentityConflictException>(() => manager.ProvisionAsync(
+            "auth",
+            request,
+            Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            "employee-token"));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_IamReadySaga_ResumesWithoutCallingIamAgain()
+    {
+        await using var context = factory.CreateDbContext();
+        var request = NewProvisionRequest();
+        var operation = new ServiceIdentityOperation
+        {
+            Id = request.OperationId,
+            WorkloadId = "auth",
+            Kind = ServiceIdentityOperationKind.Provision,
+            RequestHash = HashCanonicalRequest(
+                $"provision|auth|{request.ProfileVersion}|{request.ServiceName}|{request.HardExpiryDays}"),
+            ActorId = ActorId,
+            State = ServiceIdentityOperationState.IamReady,
+            IamPrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            IamProfileVersion = 1,
+            IamRoleId = "roles.workload.auth",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        context.ServiceIdentityOperations.Add(operation);
+        await context.SaveChangesAsync();
+        var iam = new RecordingIamClient { ThrowOnCall = true };
+        var manager = new ServiceIdentityManager(context, iam, TimeProvider.System);
+
+        var result = await manager.ProvisionAsync("auth", request, ActorId, "employee-token");
+
+        Assert.True(result.SecretRetrievable);
+        Assert.Equal(0, iam.CallCount);
+        Assert.True(await context.ServiceCredentials.AnyAsync(item => item.WorkloadId == "auth"));
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_ConcurrentSameOperation_ProducesOneVersionAndOneSecretResponse()
+    {
+        var request = NewProvisionRequest();
+        var iam = new RecordingIamClient();
+        await using var firstContext = factory.CreateDbContext();
+        await using var secondContext = factory.CreateDbContext();
+        var firstManager = new ServiceIdentityManager(firstContext, iam, TimeProvider.System);
+        var secondManager = new ServiceIdentityManager(secondContext, iam, TimeProvider.System);
+
+        var results = await Task.WhenAll(
+            firstManager.ProvisionAsync("auth", request, ActorId, "employee-token"),
+            secondManager.ProvisionAsync("auth", request, ActorId, "employee-token"));
+
+        Assert.Single(results, result => result.SecretRetrievable);
+        Assert.Single(results, result => !result.SecretRetrievable);
+        Assert.Equal(1, iam.CallCount);
+        await using var verificationContext = factory.CreateDbContext();
+        Assert.Equal(1, await verificationContext.ServiceCredentialVersions.CountAsync());
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_ExistingIdentityWithDifferentLifecycleParameters_Conflicts()
+    {
+        await using var context = factory.CreateDbContext();
+        var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
+        _ = await manager.ProvisionAsync("auth", NewProvisionRequest(), ActorId, "employee-token");
+        context.ChangeTracker.Clear();
+
+        await Assert.ThrowsAsync<ServiceIdentityConflictException>(() => manager.ProvisionAsync(
+            "auth",
+            new ProvisionServiceIdentityRequest
+            {
+                OperationId = Guid.NewGuid(),
+                ProfileVersion = 1,
+                ServiceName = "Another Service",
+                HardExpiryDays = 30
+            },
+            ActorId,
+            "employee-token"));
+    }
+
+    [Theory]
+    [InlineData("other", "roles.workload.auth")]
+    [InlineData("auth", "*")]
+    [InlineData("auth", "roles.platform.owner")]
+    public async Task ProvisionAsync_UnsafeIamResponse_DoesNotCreateCredential(
+        string returnedWorkload,
+        string returnedRole)
+    {
+        await using var context = factory.CreateDbContext();
+        var iam = new RecordingIamClient
+        {
+            Response = new WorkloadPrincipalResponse
+            {
+                WorkloadId = returnedWorkload,
+                PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                ProfileVersion = 1,
+                RoleId = returnedRole
+            }
+        };
+        var manager = new ServiceIdentityManager(context, iam, TimeProvider.System);
+
+        await Assert.ThrowsAsync<ServiceIdentityConflictException>(() => manager.ProvisionAsync(
+            "auth",
+            NewProvisionRequest(),
+            ActorId,
+            "employee-token"));
+
+        Assert.False(await context.ServiceCredentials.AnyAsync(item => item.WorkloadId == "auth"));
+        Assert.False(await context.ServiceCredentialVersions.AnyAsync());
+    }
+
+    [Fact]
+    public async Task RotateAndRevokeAsync_TransitionsActiveGraceAndRevokedAtomically()
+    {
+        await using var context = factory.CreateDbContext();
+        var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
+        var created = await manager.ProvisionAsync("auth", NewProvisionRequest(), ActorId, "employee-token");
+        context.ChangeTracker.Clear();
+
+        var rotated = await manager.RotateAsync(
+            "auth",
+            new RotateServiceIdentityRequest
+            {
+                OperationId = Guid.NewGuid(),
+                GracePeriodSeconds = 60,
+                HardExpiryDays = 30
+            },
+            ActorId);
+
+        Assert.NotEqual(created.ClientSecret, rotated.ClientSecret);
+        var versions = await context.ServiceCredentialVersions
+            .AsNoTracking()
+            .OrderBy(item => item.Version)
+            .ToListAsync();
+        Assert.Equal(ServiceCredentialVersionStatus.Grace, versions[0].Status);
+        Assert.Equal(ServiceCredentialVersionStatus.Active, versions[1].Status);
+        var logicalHash = await context.ServiceCredentials.AsNoTracking()
+            .Where(item => item.WorkloadId == "auth")
+            .Select(item => item.ClientSecretHash)
+            .SingleAsync();
+        Assert.Equal(Hash(rotated.ClientSecret!), logicalHash);
+
+        context.ChangeTracker.Clear();
+        await manager.RevokeAsync(
+            "auth",
+            new RevokeServiceIdentityRequest { OperationId = Guid.NewGuid() },
+            ActorId);
+        Assert.False(await context.ServiceCredentials.AsNoTracking().Where(item => item.WorkloadId == "auth")
+            .Select(item => item.IsActive).SingleAsync());
+        Assert.All(
+            await context.ServiceCredentialVersions.AsNoTracking().ToListAsync(),
+            version => Assert.Equal(ServiceCredentialVersionStatus.Revoked, version.Status));
+    }
+
+    [Fact]
+    public async Task RotateAsync_Twice_OnlyImmediatePriorSecretRemainsGrace()
+    {
+        await using var context = factory.CreateDbContext();
+        var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
+        _ = await manager.ProvisionAsync("auth", NewProvisionRequest(), ActorId, "employee-token");
+        context.ChangeTracker.Clear();
+        _ = await manager.RotateAsync(
+            "auth",
+            new RotateServiceIdentityRequest { OperationId = Guid.NewGuid(), GracePeriodSeconds = 60 },
+            ActorId);
+        context.ChangeTracker.Clear();
+
+        _ = await manager.RotateAsync(
+            "auth",
+            new RotateServiceIdentityRequest { OperationId = Guid.NewGuid(), GracePeriodSeconds = 60 },
+            ActorId);
+
+        var states = await context.ServiceCredentialVersions.AsNoTracking()
+            .OrderBy(item => item.Version)
+            .Select(item => item.Status)
+            .ToListAsync();
+        Assert.Equal(
+            [
+                ServiceCredentialVersionStatus.Revoked,
+                ServiceCredentialVersionStatus.Grace,
+                ServiceCredentialVersionStatus.Active
+            ],
+            states);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_CredentialCommittedResume_CompletesWithoutDuplicateAudit()
+    {
+        await using var context = factory.CreateDbContext();
+        var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
+        _ = await manager.ProvisionAsync("auth", NewProvisionRequest(), ActorId, "employee-token");
+        var operationId = Guid.NewGuid();
+        context.ServiceIdentityOperations.Add(new ServiceIdentityOperation
+        {
+            Id = operationId,
+            WorkloadId = "auth",
+            Kind = ServiceIdentityOperationKind.Revoke,
+            RequestHash = HashCanonicalRequest("revoke|auth"),
+            ActorId = ActorId,
+            State = ServiceIdentityOperationState.CredentialCommitted,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+        await context.SaveChangesAsync();
+        var auditCount = await context.AuthAuditLogs.CountAsync();
+        context.ChangeTracker.Clear();
+
+        await manager.RevokeAsync(
+            "auth",
+            new RevokeServiceIdentityRequest { OperationId = operationId },
+            ActorId);
+
+        Assert.Equal(auditCount, await context.AuthAuditLogs.CountAsync());
+        Assert.Equal(
+            ServiceIdentityOperationState.Completed,
+            await context.ServiceIdentityOperations.AsNoTracking()
+                .Where(item => item.Id == operationId)
+                .Select(item => item.State)
+                .SingleAsync());
+    }
+
+    private static ProvisionServiceIdentityRequest NewProvisionRequest() => new()
+    {
+        OperationId = Guid.NewGuid(),
+        ProfileVersion = 1,
+        ServiceName = "Auth Service",
+        HardExpiryDays = 30
+    };
+
+    private static string HashCanonicalRequest(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+    private static string Hash(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+    private static async Task<string> DumpStringColumnsAsync(Maliev.AuthService.Infrastructure.DbContexts.AuthDbContext context)
+    {
+        var credential = await context.ServiceCredentials.AsNoTracking().SingleAsync(item => item.WorkloadId == "auth");
+        var operation = await context.ServiceIdentityOperations.AsNoTracking().SingleAsync();
+        return string.Join('|',
+            credential.ClientId,
+            credential.ClientSecretHash,
+            credential.ServiceName,
+            credential.WorkloadId,
+            credential.RoleId,
+            operation.RequestHash,
+            operation.IamRoleId);
+    }
+
+    private sealed class RecordingIamClient : IWorkloadIdentityIamClient
+    {
+        public int CallCount { get; private set; }
+
+        public string? LastBearerToken { get; private set; }
+
+        public WorkloadPrincipalResponse Response { get; init; } = new()
+        {
+            WorkloadId = "auth",
+            PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            ProfileVersion = 1,
+            RoleId = "roles.workload.auth"
+        };
+
+        public bool ThrowOnCall { get; init; }
+
+        public Task<WorkloadPrincipalResponse> ProvisionAsync(
+            string workloadId,
+            ProvisionWorkloadPrincipalRequest request,
+            string callerBearerToken,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            if (ThrowOnCall)
+            {
+                throw new InvalidOperationException("IAM must not be called for an IamReady resume");
+            }
+
+            LastBearerToken = callerBearerToken;
+            return Task.FromResult(Response);
+        }
+    }
+}

--- a/Maliev.AuthService.Tests/Integration/ServiceIdentityManagerTests.cs
+++ b/Maliev.AuthService.Tests/Integration/ServiceIdentityManagerTests.cs
@@ -15,6 +15,8 @@ namespace Maliev.AuthService.Tests.Integration;
 public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factory) : IAsyncLifetime
 {
     private static readonly Guid ActorId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private const string WorkloadId = "auth-service";
+    private const string ExpectedRoleId = "roles.workloads.auth-service.v1";
 
     public Task InitializeAsync() => factory.CleanDatabaseAsync();
 
@@ -28,9 +30,9 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
         var manager = new ServiceIdentityManager(context, iam, TimeProvider.System);
         var request = NewProvisionRequest();
 
-        var created = await manager.ProvisionAsync("auth", request, ActorId, "employee-token");
+        var created = await manager.ProvisionAsync(WorkloadId, request, ActorId, "employee-token");
         context.ChangeTracker.Clear();
-        var replay = await manager.ProvisionAsync("auth", request, ActorId, "employee-token");
+        var replay = await manager.ProvisionAsync(WorkloadId, request, ActorId, "employee-token");
 
         Assert.True(created.SecretRetrievable);
         Assert.NotNull(created.ClientSecret);
@@ -52,11 +54,11 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
         await using var context = factory.CreateDbContext();
         var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
         var request = NewProvisionRequest();
-        _ = await manager.ProvisionAsync("auth", request, ActorId, "employee-token");
+        _ = await manager.ProvisionAsync(WorkloadId, request, ActorId, "employee-token");
         context.ChangeTracker.Clear();
 
         await Assert.ThrowsAsync<ServiceIdentityConflictException>(() => manager.ProvisionAsync(
-            "auth",
+            WorkloadId,
             request,
             Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
             "employee-token"));
@@ -70,15 +72,15 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
         var operation = new ServiceIdentityOperation
         {
             Id = request.OperationId,
-            WorkloadId = "auth",
+            WorkloadId = WorkloadId,
             Kind = ServiceIdentityOperationKind.Provision,
             RequestHash = HashCanonicalRequest(
-                $"provision|auth|{request.ProfileVersion}|{request.ServiceName}|{request.HardExpiryDays}"),
+                $"provision|{WorkloadId}|{request.ProfileVersion}|{request.ServiceName}|{request.HardExpiryDays}"),
             ActorId = ActorId,
             State = ServiceIdentityOperationState.IamReady,
             IamPrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
             IamProfileVersion = 1,
-            IamRoleId = "roles.workload.auth",
+            IamRoleId = ExpectedRoleId,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow
         };
@@ -87,11 +89,11 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
         var iam = new RecordingIamClient { ThrowOnCall = true };
         var manager = new ServiceIdentityManager(context, iam, TimeProvider.System);
 
-        var result = await manager.ProvisionAsync("auth", request, ActorId, "employee-token");
+        var result = await manager.ProvisionAsync(WorkloadId, request, ActorId, "employee-token");
 
         Assert.True(result.SecretRetrievable);
         Assert.Equal(0, iam.CallCount);
-        Assert.True(await context.ServiceCredentials.AnyAsync(item => item.WorkloadId == "auth"));
+        Assert.True(await context.ServiceCredentials.AnyAsync(item => item.WorkloadId == WorkloadId));
     }
 
     [Fact]
@@ -105,8 +107,8 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
         var secondManager = new ServiceIdentityManager(secondContext, iam, TimeProvider.System);
 
         var results = await Task.WhenAll(
-            firstManager.ProvisionAsync("auth", request, ActorId, "employee-token"),
-            secondManager.ProvisionAsync("auth", request, ActorId, "employee-token"));
+            firstManager.ProvisionAsync(WorkloadId, request, ActorId, "employee-token"),
+            secondManager.ProvisionAsync(WorkloadId, request, ActorId, "employee-token"));
 
         Assert.Single(results, result => result.SecretRetrievable);
         Assert.Single(results, result => !result.SecretRetrievable);
@@ -120,11 +122,11 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
     {
         await using var context = factory.CreateDbContext();
         var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
-        _ = await manager.ProvisionAsync("auth", NewProvisionRequest(), ActorId, "employee-token");
+        _ = await manager.ProvisionAsync(WorkloadId, NewProvisionRequest(), ActorId, "employee-token");
         context.ChangeTracker.Clear();
 
         await Assert.ThrowsAsync<ServiceIdentityConflictException>(() => manager.ProvisionAsync(
-            "auth",
+            WorkloadId,
             new ProvisionServiceIdentityRequest
             {
                 OperationId = Guid.NewGuid(),
@@ -137,9 +139,11 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
     }
 
     [Theory]
-    [InlineData("other", "roles.workload.auth")]
-    [InlineData("auth", "*")]
-    [InlineData("auth", "roles.platform.owner")]
+    [InlineData("other", ExpectedRoleId)]
+    [InlineData(WorkloadId, "*")]
+    [InlineData(WorkloadId, "roles.iam.admin")]
+    [InlineData(WorkloadId, "roles.workloads.other.v1")]
+    [InlineData(WorkloadId, "roles.workloads.auth-service.v2")]
     public async Task ProvisionAsync_UnsafeIamResponse_DoesNotCreateCredential(
         string returnedWorkload,
         string returnedRole)
@@ -158,12 +162,12 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
         var manager = new ServiceIdentityManager(context, iam, TimeProvider.System);
 
         await Assert.ThrowsAsync<ServiceIdentityConflictException>(() => manager.ProvisionAsync(
-            "auth",
+            WorkloadId,
             NewProvisionRequest(),
             ActorId,
             "employee-token"));
 
-        Assert.False(await context.ServiceCredentials.AnyAsync(item => item.WorkloadId == "auth"));
+        Assert.False(await context.ServiceCredentials.AnyAsync(item => item.WorkloadId == WorkloadId));
         Assert.False(await context.ServiceCredentialVersions.AnyAsync());
     }
 
@@ -172,11 +176,11 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
     {
         await using var context = factory.CreateDbContext();
         var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
-        var created = await manager.ProvisionAsync("auth", NewProvisionRequest(), ActorId, "employee-token");
+        var created = await manager.ProvisionAsync(WorkloadId, NewProvisionRequest(), ActorId, "employee-token");
         context.ChangeTracker.Clear();
 
         var rotated = await manager.RotateAsync(
-            "auth",
+            WorkloadId,
             new RotateServiceIdentityRequest
             {
                 OperationId = Guid.NewGuid(),
@@ -193,17 +197,17 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
         Assert.Equal(ServiceCredentialVersionStatus.Grace, versions[0].Status);
         Assert.Equal(ServiceCredentialVersionStatus.Active, versions[1].Status);
         var logicalHash = await context.ServiceCredentials.AsNoTracking()
-            .Where(item => item.WorkloadId == "auth")
+            .Where(item => item.WorkloadId == WorkloadId)
             .Select(item => item.ClientSecretHash)
             .SingleAsync();
         Assert.Equal(Hash(rotated.ClientSecret!), logicalHash);
 
         context.ChangeTracker.Clear();
         await manager.RevokeAsync(
-            "auth",
+            WorkloadId,
             new RevokeServiceIdentityRequest { OperationId = Guid.NewGuid() },
             ActorId);
-        Assert.False(await context.ServiceCredentials.AsNoTracking().Where(item => item.WorkloadId == "auth")
+        Assert.False(await context.ServiceCredentials.AsNoTracking().Where(item => item.WorkloadId == WorkloadId)
             .Select(item => item.IsActive).SingleAsync());
         Assert.All(
             await context.ServiceCredentialVersions.AsNoTracking().ToListAsync(),
@@ -215,16 +219,16 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
     {
         await using var context = factory.CreateDbContext();
         var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
-        _ = await manager.ProvisionAsync("auth", NewProvisionRequest(), ActorId, "employee-token");
+        _ = await manager.ProvisionAsync(WorkloadId, NewProvisionRequest(), ActorId, "employee-token");
         context.ChangeTracker.Clear();
         _ = await manager.RotateAsync(
-            "auth",
+            WorkloadId,
             new RotateServiceIdentityRequest { OperationId = Guid.NewGuid(), GracePeriodSeconds = 60 },
             ActorId);
         context.ChangeTracker.Clear();
 
         _ = await manager.RotateAsync(
-            "auth",
+            WorkloadId,
             new RotateServiceIdentityRequest { OperationId = Guid.NewGuid(), GracePeriodSeconds = 60 },
             ActorId);
 
@@ -246,14 +250,14 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
     {
         await using var context = factory.CreateDbContext();
         var manager = new ServiceIdentityManager(context, new RecordingIamClient(), TimeProvider.System);
-        _ = await manager.ProvisionAsync("auth", NewProvisionRequest(), ActorId, "employee-token");
+        _ = await manager.ProvisionAsync(WorkloadId, NewProvisionRequest(), ActorId, "employee-token");
         var operationId = Guid.NewGuid();
         context.ServiceIdentityOperations.Add(new ServiceIdentityOperation
         {
             Id = operationId,
-            WorkloadId = "auth",
+            WorkloadId = WorkloadId,
             Kind = ServiceIdentityOperationKind.Revoke,
-            RequestHash = HashCanonicalRequest("revoke|auth"),
+            RequestHash = HashCanonicalRequest($"revoke|{WorkloadId}"),
             ActorId = ActorId,
             State = ServiceIdentityOperationState.CredentialCommitted,
             CreatedAt = DateTimeOffset.UtcNow,
@@ -264,7 +268,7 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
         context.ChangeTracker.Clear();
 
         await manager.RevokeAsync(
-            "auth",
+            WorkloadId,
             new RevokeServiceIdentityRequest { OperationId = operationId },
             ActorId);
 
@@ -293,7 +297,7 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
 
     private static async Task<string> DumpStringColumnsAsync(Maliev.AuthService.Infrastructure.DbContexts.AuthDbContext context)
     {
-        var credential = await context.ServiceCredentials.AsNoTracking().SingleAsync(item => item.WorkloadId == "auth");
+        var credential = await context.ServiceCredentials.AsNoTracking().SingleAsync(item => item.WorkloadId == WorkloadId);
         var operation = await context.ServiceIdentityOperations.AsNoTracking().SingleAsync();
         return string.Join('|',
             credential.ClientId,
@@ -313,10 +317,10 @@ public sealed class ServiceIdentityManagerTests(TestWebApplicationFactory factor
 
         public WorkloadPrincipalResponse Response { get; init; } = new()
         {
-            WorkloadId = "auth",
+            WorkloadId = WorkloadId,
             PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
             ProfileVersion = 1,
-            RoleId = "roles.workload.auth"
+            RoleId = ExpectedRoleId
         };
 
         public bool ThrowOnCall { get; init; }

--- a/Maliev.AuthService.Tests/Unit/ServiceIdentityContractTests.cs
+++ b/Maliev.AuthService.Tests/Unit/ServiceIdentityContractTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Net;
 using Maliev.Aspire.ServiceDefaults.Authorization;
 using Maliev.AuthService.Api.Authorization;
 using Maliev.AuthService.Api.Controllers;
@@ -8,6 +9,7 @@ using Maliev.AuthService.Application.Interfaces;
 using Maliev.AuthService.Domain.Entities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Moq;
 using System.Security.Claims;
 using Xunit;
@@ -152,6 +154,48 @@ public sealed class ServiceIdentityContractTests
         Assert.Equal(StatusCodes.Status503ServiceUnavailable, unavailable.StatusCode);
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden, StatusCodes.Status403Forbidden)]
+    [InlineData(HttpStatusCode.Conflict, StatusCodes.Status409Conflict)]
+    public async Task Provision_IamAuthorizationOrConflict_PreservesSafeStatus(
+        HttpStatusCode iamStatus,
+        int expectedStatus)
+    {
+        var actorId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var request = new ProvisionServiceIdentityRequest
+        {
+            ProfileVersion = 1,
+            OperationId = Guid.NewGuid(),
+            ServiceName = "Auth Service"
+        };
+        var manager = new Mock<IServiceIdentityManager>(MockBehavior.Strict);
+        manager.Setup(service => service.ProvisionAsync(
+                "auth",
+                request,
+                actorId,
+                "employee-token",
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("untrusted upstream body", null, iamStatus));
+        var controller = CreateController(manager.Object,
+            new Claim("user_type", "employee"),
+            new Claim("sub", actorId.ToString("D")));
+        controller.Request.Headers.Authorization = "Bearer employee-token";
+
+        var result = await controller.Provision("auth", request, CancellationToken.None);
+
+        if (expectedStatus == StatusCodes.Status403Forbidden)
+        {
+            Assert.IsType<ForbidResult>(result);
+        }
+        else
+        {
+            var status = Assert.IsAssignableFrom<IStatusCodeActionResult>(result);
+            Assert.Equal(expectedStatus, status.StatusCode);
+        }
+
+        Assert.DoesNotContain("untrusted upstream body", result.ToString(), StringComparison.Ordinal);
+    }
+
     private static ServiceIdentitiesController CreateController(
         IServiceIdentityManager manager,
         params Claim[] claims) => new(manager)
@@ -171,7 +215,7 @@ public sealed class ServiceIdentityContractTests
         ClientId = "service-auth",
         PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
         ProfileVersion = 1,
-        RoleId = "roles.workload.auth",
+        RoleId = "roles.workloads.auth.v1",
         IsActive = true,
         CredentialVersion = 1,
         ClientSecret = "one-time-secret",

--- a/Maliev.AuthService.Tests/Unit/ServiceIdentityContractTests.cs
+++ b/Maliev.AuthService.Tests/Unit/ServiceIdentityContractTests.cs
@@ -1,0 +1,181 @@
+using System.Reflection;
+using Maliev.Aspire.ServiceDefaults.Authorization;
+using Maliev.AuthService.Api.Authorization;
+using Maliev.AuthService.Api.Controllers;
+using Maliev.AuthService.Application.DTOs.Request;
+using Maliev.AuthService.Application.DTOs.Response;
+using Maliev.AuthService.Application.Interfaces;
+using Maliev.AuthService.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+public sealed class ServiceIdentityContractTests
+{
+    [Theory]
+    [InlineData(nameof(ServiceIdentitiesController.Provision), AuthPermissions.ProvisionServiceIdentities)]
+    [InlineData(nameof(ServiceIdentitiesController.Get), AuthPermissions.ReadServiceIdentities)]
+    [InlineData(nameof(ServiceIdentitiesController.Rotate), AuthPermissions.RotateServiceIdentities)]
+    [InlineData(nameof(ServiceIdentitiesController.Revoke), AuthPermissions.RevokeServiceIdentities)]
+    public void Endpoint_DeclaresDedicatedPermission(string methodName, string expectedPermission)
+    {
+        var method = typeof(ServiceIdentitiesController).GetMethod(methodName);
+
+        var permission = method?.GetCustomAttribute<RequirePermissionAttribute>();
+
+        Assert.NotNull(permission);
+        Assert.Equal(expectedPermission, permission.Permission);
+        Assert.True(permission.IsCritical);
+        Assert.True(permission.RequireLiveCheck);
+    }
+
+    [Fact]
+    public void CredentialVersion_CannotAuthenticateWhilePendingOrExpired()
+    {
+        var now = new DateTimeOffset(2026, 7, 16, 0, 0, 0, TimeSpan.Zero);
+        var version = new ServiceCredentialVersion
+        {
+            Status = ServiceCredentialVersionStatus.Pending,
+            HardExpiresAt = now.AddHours(1)
+        };
+
+        Assert.False(version.CanAuthenticate(now));
+
+        version.Status = ServiceCredentialVersionStatus.Active;
+        version.HardExpiresAt = now;
+        Assert.False(version.CanAuthenticate(now));
+    }
+
+    [Theory]
+    [InlineData(ServiceCredentialVersionStatus.Active)]
+    [InlineData(ServiceCredentialVersionStatus.Grace)]
+    public void CredentialVersion_ActiveOrGraceBeforeExpiry_CanAuthenticate(
+        ServiceCredentialVersionStatus status)
+    {
+        var now = new DateTimeOffset(2026, 7, 16, 0, 0, 0, TimeSpan.Zero);
+        var version = new ServiceCredentialVersion
+        {
+            Status = status,
+            HardExpiresAt = now.AddMinutes(1),
+            GraceExpiresAt = status == ServiceCredentialVersionStatus.Grace
+                ? now.AddSeconds(30)
+                : null
+        };
+
+        Assert.True(version.CanAuthenticate(now));
+    }
+
+    [Fact]
+    public async Task Provision_ExactEmployeeSubject_ForwardsOriginalBearer()
+    {
+        var actorId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var manager = new Mock<IServiceIdentityManager>(MockBehavior.Strict);
+        var request = new ProvisionServiceIdentityRequest
+        {
+            ProfileVersion = 1,
+            OperationId = Guid.NewGuid(),
+            ServiceName = "Auth Service"
+        };
+        manager.Setup(service => service.ProvisionAsync(
+                "auth",
+                request,
+                actorId,
+                "employee-token",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewResponse());
+        var controller = CreateController(manager.Object,
+            new Claim("user_type", "employee"),
+            new Claim("sub", actorId.ToString("D")));
+        controller.Request.Headers.Authorization = "Bearer employee-token";
+
+        var result = await controller.Provision("auth", request, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("no-store", controller.Response.Headers.CacheControl);
+        Assert.Equal("no-cache", controller.Response.Headers.Pragma);
+        manager.VerifyAll();
+    }
+
+    [Fact]
+    public async Task Provision_DuplicateSubjectOrServiceIdentity_IsForbiddenBeforeManager()
+    {
+        var manager = new Mock<IServiceIdentityManager>(MockBehavior.Strict);
+        var actorId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var request = new ProvisionServiceIdentityRequest
+        {
+            ProfileVersion = 1,
+            OperationId = Guid.NewGuid(),
+            ServiceName = "Auth Service"
+        };
+        var controller = CreateController(manager.Object,
+            new Claim("user_type", "service"),
+            new Claim("sub", actorId.ToString("D")),
+            new Claim("sub", Guid.NewGuid().ToString("D")));
+        controller.Request.Headers.Authorization = "Bearer service-token";
+
+        var result = await controller.Provision("auth", request, CancellationToken.None);
+
+        Assert.IsType<ForbidResult>(result);
+        manager.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Provision_IamTimeoutWithoutCallerCancellation_ReturnsServiceUnavailable()
+    {
+        var actorId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var request = new ProvisionServiceIdentityRequest
+        {
+            ProfileVersion = 1,
+            OperationId = Guid.NewGuid(),
+            ServiceName = "Auth Service"
+        };
+        var manager = new Mock<IServiceIdentityManager>(MockBehavior.Strict);
+        manager.Setup(service => service.ProvisionAsync(
+                "auth",
+                request,
+                actorId,
+                "employee-token",
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("IAM timeout"));
+        var controller = CreateController(manager.Object,
+            new Claim("user_type", "employee"),
+            new Claim("sub", actorId.ToString("D")));
+        controller.Request.Headers.Authorization = "Bearer employee-token";
+
+        var result = await controller.Provision("auth", request, CancellationToken.None);
+
+        var unavailable = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, unavailable.StatusCode);
+    }
+
+    private static ServiceIdentitiesController CreateController(
+        IServiceIdentityManager manager,
+        params Claim[] claims) => new(manager)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, "test"))
+                }
+            }
+        };
+
+    private static ServiceIdentityResponse NewResponse() => new()
+    {
+        WorkloadId = "auth",
+        ClientId = "service-auth",
+        PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+        ProfileVersion = 1,
+        RoleId = "roles.workload.auth",
+        IsActive = true,
+        CredentialVersion = 1,
+        ClientSecret = "one-time-secret",
+        SecretRetrievable = true,
+        HardExpiresAt = DateTimeOffset.UtcNow.AddDays(1)
+    };
+}

--- a/Maliev.AuthService.Tests/Unit/ServiceIdentityIamContractTests.cs
+++ b/Maliev.AuthService.Tests/Unit/ServiceIdentityIamContractTests.cs
@@ -1,0 +1,49 @@
+using Maliev.AuthService.Infrastructure.Services;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+public sealed class ServiceIdentityIamContractTests
+{
+    [Theory]
+    [InlineData("auth-service")]
+    [InlineData("quote-engine")]
+    [InlineData("service-123")]
+    [InlineData("a")]
+    public void ValidateWorkloadId_CanonicalKebab_ReturnsValue(string workloadId)
+    {
+        Assert.Equal(workloadId, ServiceIdentityIamContract.ValidateWorkloadId(workloadId));
+    }
+
+    [Theory]
+    [InlineData("Auth")]
+    [InlineData("quote.engine")]
+    [InlineData("-auth")]
+    [InlineData("auth-")]
+    [InlineData("auth--service")]
+    [InlineData("auth_service")]
+    [InlineData(" auth")]
+    [InlineData("auth ")]
+    public void ValidateWorkloadId_Noncanonical_Throws(string workloadId)
+    {
+        Assert.Throws<ArgumentException>(() => ServiceIdentityIamContract.ValidateWorkloadId(workloadId));
+    }
+
+    [Fact]
+    public void ValidateWorkloadId_OverOneHundredCharacters_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            ServiceIdentityIamContract.ValidateWorkloadId(new string('a', 101)));
+    }
+
+    [Theory]
+    [InlineData("auth-service", 1, "roles.workloads.auth-service.v1")]
+    [InlineData("quote-engine", 42, "roles.workloads.quote-engine.v42")]
+    public void ExpectedRoleId_UsesDeterministicIamContract(
+        string workloadId,
+        int profileVersion,
+        string expected)
+    {
+        Assert.Equal(expected, ServiceIdentityIamContract.ExpectedRoleId(workloadId, profileVersion));
+    }
+}

--- a/Maliev.AuthService.Tests/Unit/WorkloadIdentityIamClientTests.cs
+++ b/Maliev.AuthService.Tests/Unit/WorkloadIdentityIamClientTests.cs
@@ -18,19 +18,19 @@ public sealed class WorkloadIdentityIamClientTests
         var operationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
         var result = await client.ProvisionAsync(
-            "auth",
-            new ProvisionWorkloadPrincipalRequest { ProfileVersion = 2, OperationId = operationId },
+            "auth-service",
+            new ProvisionWorkloadPrincipalRequest { ProfileVersion = 1, OperationId = operationId },
             "employee-token");
 
-        Assert.Equal("/iam/v1/workload-principals/auth", handler.RequestUri?.AbsolutePath);
+        Assert.Equal("/iam/v1/workload-principals/auth-service", handler.RequestUri?.AbsolutePath);
         Assert.Equal("Bearer", handler.AuthorizationScheme);
         Assert.Equal("employee-token", handler.AuthorizationParameter);
         using var document = JsonDocument.Parse(Assert.IsType<string>(handler.Body));
-        Assert.Equal(2, document.RootElement.GetProperty("profile_version").GetInt32());
+        Assert.Equal(1, document.RootElement.GetProperty("profile_version").GetInt32());
         Assert.Equal(operationId, document.RootElement.GetProperty("operation_id").GetGuid());
         Assert.False(document.RootElement.TryGetProperty("ProfileVersion", out _));
-        Assert.Equal("auth", result.WorkloadId);
-        Assert.Equal("roles.workload.auth", result.RoleId);
+        Assert.Equal("auth-service", result.WorkloadId);
+        Assert.Equal("roles.workloads.auth-service.v1", result.RoleId);
     }
 
     private sealed class RecordingHandler : HttpMessageHandler
@@ -55,10 +55,10 @@ public sealed class WorkloadIdentityIamClientTests
             {
                 Content = JsonContent.Create(new
                 {
-                    workload_id = "auth",
+                    workload_id = "auth-service",
                     principal_id = "11111111-1111-1111-1111-111111111111",
-                    profile_version = 2,
-                    role_id = "roles.workload.auth"
+                    profile_version = 1,
+                    role_id = "roles.workloads.auth-service.v1"
                 })
             };
         }

--- a/Maliev.AuthService.Tests/Unit/WorkloadIdentityIamClientTests.cs
+++ b/Maliev.AuthService.Tests/Unit/WorkloadIdentityIamClientTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Maliev.AuthService.Application.DTOs.IAM;
+using Maliev.AuthService.Infrastructure.HttpClients;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+public sealed class WorkloadIdentityIamClientTests
+{
+    [Fact]
+    public async Task ProvisionAsync_ForwardsOnlyCallerBearerAndExactSnakeCaseContract()
+    {
+        var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://iam.test") };
+        var client = new WorkloadIdentityIamClient(httpClient);
+        var operationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+        var result = await client.ProvisionAsync(
+            "auth",
+            new ProvisionWorkloadPrincipalRequest { ProfileVersion = 2, OperationId = operationId },
+            "employee-token");
+
+        Assert.Equal("/iam/v1/workload-principals/auth", handler.RequestUri?.AbsolutePath);
+        Assert.Equal("Bearer", handler.AuthorizationScheme);
+        Assert.Equal("employee-token", handler.AuthorizationParameter);
+        using var document = JsonDocument.Parse(Assert.IsType<string>(handler.Body));
+        Assert.Equal(2, document.RootElement.GetProperty("profile_version").GetInt32());
+        Assert.Equal(operationId, document.RootElement.GetProperty("operation_id").GetGuid());
+        Assert.False(document.RootElement.TryGetProperty("ProfileVersion", out _));
+        Assert.Equal("auth", result.WorkloadId);
+        Assert.Equal("roles.workload.auth", result.RoleId);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public Uri? RequestUri { get; private set; }
+
+        public string? AuthorizationScheme { get; private set; }
+
+        public string? AuthorizationParameter { get; private set; }
+
+        public string? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestUri = request.RequestUri;
+            AuthorizationScheme = request.Headers.Authorization?.Scheme;
+            AuthorizationParameter = request.Headers.Authorization?.Parameter;
+            Body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new
+                {
+                    workload_id = "auth",
+                    principal_id = "11111111-1111-1111-1111-111111111111",
+                    profile_version = 2,
+                    role_id = "roles.workload.auth"
+                })
+            };
+        }
+    }
+}

--- a/Maliev.AuthService.Tests/Unit/WorkloadIdentityIamEndpointOptionsTests.cs
+++ b/Maliev.AuthService.Tests/Unit/WorkloadIdentityIamEndpointOptionsTests.cs
@@ -1,0 +1,116 @@
+using Maliev.AuthService.Infrastructure.HttpClients;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+public sealed class WorkloadIdentityIamEndpointOptionsTests
+{
+    [Theory]
+    [InlineData("Development", "https+http://IAMService")]
+    [InlineData("Testing", "https+http://IAMService")]
+    [InlineData("Production", "https://IAMService")]
+    [InlineData("Staging", "https://IAMService")]
+    public void Resolve_NoConfiguredBaseUrl_UsesEnvironmentSafeDefault(
+        string environmentName,
+        string expected)
+    {
+        var resolver = new WorkloadIdentityIamEndpointResolver(new TestEnvironment(environmentName));
+
+        var result = resolver.Resolve(new WorkloadIdentityIamEndpointOptions());
+
+        Assert.Equal(expected, result.OriginalString);
+    }
+
+    [Theory]
+    [InlineData("Production", "https://iam.internal")]
+    [InlineData("Development", "https://iam.internal:7443")]
+    [InlineData("Development", "http://localhost:5100")]
+    [InlineData("Testing", "http://127.0.0.1:5100")]
+    [InlineData("Testing", "http://[::1]:5100")]
+    public void Resolve_CanonicalTrustedOrigin_ReturnsConfiguredOrigin(
+        string environmentName,
+        string baseUrl)
+    {
+        var resolver = new WorkloadIdentityIamEndpointResolver(new TestEnvironment(environmentName));
+
+        var result = resolver.Resolve(new WorkloadIdentityIamEndpointOptions { BaseUrl = baseUrl });
+
+        Assert.Equal(baseUrl, result.OriginalString);
+    }
+
+    [Theory]
+    [InlineData("Production", "http://localhost:5100")]
+    [InlineData("Development", "http://iam.internal")]
+    [InlineData("Development", " https://iam.internal")]
+    [InlineData("Development", "https://iam.internal ")]
+    [InlineData("Development", "HTTPS://iam.internal")]
+    [InlineData("Development", "https://IAM.INTERNAL")]
+    [InlineData("Development", "https://user@iam.internal")]
+    [InlineData("Development", "https://iam.internal/")]
+    [InlineData("Development", "https://iam.internal/path")]
+    [InlineData("Development", "https://iam.internal?query=1")]
+    [InlineData("Development", "https://iam.internal#fragment")]
+    [InlineData("Development", "https+http://IAMService")]
+    public void Resolve_UntrustedOrNoncanonicalOrigin_ThrowsOptionsValidation(
+        string environmentName,
+        string baseUrl)
+    {
+        var resolver = new WorkloadIdentityIamEndpointResolver(new TestEnvironment(environmentName));
+
+        Assert.Throws<OptionsValidationException>(() =>
+            resolver.Resolve(new WorkloadIdentityIamEndpointOptions { BaseUrl = baseUrl }));
+    }
+
+    [Fact]
+    public void AddWorkloadIdentityIamEndpoint_UnsafeConfiguredOrigin_FailsOptionsResolution()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["Services:IAMService:BaseUrl"] = "http://iam.internal"
+            }).Build();
+        var services = new ServiceCollection();
+
+        services.AddWorkloadIdentityIamEndpoint(
+            configuration.GetSection("Services:IAMService"),
+            new TestEnvironment(Environments.Production));
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Throws<OptionsValidationException>(() =>
+            provider.GetRequiredService<IOptions<WorkloadIdentityIamEndpointOptions>>().Value);
+    }
+
+    [Fact]
+    public async Task AddWorkloadIdentityIamEndpoint_UnsafeProductionOrigin_FailsHostStartup()
+    {
+        using var host = new HostBuilder()
+            .UseEnvironment(Environments.Production)
+            .ConfigureAppConfiguration(configuration => configuration.AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["Services:IAMService:BaseUrl"] = "http://127.0.0.1:5100"
+                }))
+            .ConfigureServices((context, services) => services.AddWorkloadIdentityIamEndpoint(
+                context.Configuration.GetSection("Services:IAMService"),
+                context.HostingEnvironment))
+            .Build();
+
+        await Assert.ThrowsAsync<OptionsValidationException>(() => host.StartAsync());
+    }
+
+    private sealed class TestEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+
+        public string ApplicationName { get; set; } = "AuthService.Tests";
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}


### PR DESCRIPTION
## Outcome

Adds AuthService's persisted, IAM-backed service-identity credential lifecycle. This is the second #75 foundation phase: it provisions only the reviewed `auth-service` v1 identity and does not seed Aspire, cut over consumers, change GitOps, or deploy.

## Trust boundary

- Separate `service-identities` controller with live-checked employee permissions for provision/read/rotate/revoke.
- For provisioning only, forwards the already validated employee bearer to IAM; no fleet bootstrap secret or Auth service token is substituted.
- IAM endpoint is canonical HTTPS outside Development/Testing; plaintext is allowed there only for exact loopback origins.
- Verifies exact IAM response: `auth-service`, profile v1, nonempty principal, `roles.workloads.auth-service.v1`.
- Safely preserves IAM 403/409; network/timeouts map to 503 without forwarding response bodies.

## Credential lifecycle

- Additive persisted saga: `Started -> IamReady -> CredentialCommitted -> Completed`.
- Actor/request-bound idempotency and PostgreSQL advisory workload locks across pods.
- One-time 256-bit Base64Url secret; only SHA-256 hash is stored.
- Secret responses use `Cache-Control: no-store` and `Pragma: no-cache`; replay returns metadata with `secret_retrievable=false`.
- Versioned Active/Grace/Revoked states, bounded hard expiry, logical revoke, and fixed-time managed service login.
- Rotation mirrors the current hash into the legacy column for safe old-binary rollback while version state remains authoritative for upgraded binaries.
- Interrupted one-time delivery deliberately does not escrow plaintext; an authorized zero-grace rotation is the bounded recovery path.

## Validation

- Full tests: 372/372.
- Final focused transport/contract independent review: 64/64, clear.
- PostgreSQL lifecycle, cross-context concurrency, recovery, login, IAM wire/status, and migration tests: green.
- Release build: 0 warnings, 0 errors.
- Format and EF model drift: clean.
- Dependency audit: no vulnerable packages.
- gitleaks, diff, cleanup, and pre-commit checks: clean.
- Independent security and migration re-reviews: clear.

## Deliberate exclusions

- no Aspire local identity seeding;
- no fleet profile catalog or consumer cutover;
- no wildcard/local-signer removal;
- no GitOps, Argo, or deployment changes.

Tracks MALIEV-Co-Ltd/maliev-ops#75. Logically depends on IAMService PR https://github.com/MALIEV-Co-Ltd/Maliev.IAMService/pull/19. Issue #75 remains open after merge.