### PR TITLE
feat(auth): bind token issuance to IAM capability

### DIFF
--- a/Maliev.AuthService.Api/Program.cs
+++ b/Maliev.AuthService.Api/Program.cs
@@ -113,6 +113,21 @@ try
     .AddServiceDiscovery()
     .AddHttpMessageHandler<Maliev.Aspire.ServiceDefaults.IAM.ServiceAccountAuthenticationHandler>();
 
+    // Isolated Auth-only capability client used exclusively by service-login token issuance.
+    // Signing-key validation is deliberately deferred to each service-login call so a missing
+    // rotation secret cannot crash unrelated AuthService startup and user authentication flows.
+    builder.Services.AddOptions<TokenIssuanceCapabilityOptions>()
+        .Bind(builder.Configuration.GetSection(TokenIssuanceCapabilityOptions.ConfigurationSection));
+    builder.Services.AddSingleton<ITokenIssuanceCapabilitySigner, TokenIssuanceCapabilitySigner>();
+    builder.Services.AddHttpClient<ITokenIssuancePermissionClient, TokenIssuancePermissionClient>(client =>
+    {
+        var explicitUrl = builder.Configuration["Services:IAMService:BaseUrl"];
+        client.BaseAddress = !string.IsNullOrEmpty(explicitUrl)
+            ? new Uri(explicitUrl)
+            : new Uri("https+http://IAMService");
+        client.Timeout = TimeSpan.FromSeconds(10);
+    }).AddServiceDiscovery();
+
     // Dedicated human-authorized client for IAM workload provisioning. It intentionally
     // has no service-account authentication handler because the controller forwards only
     // the already validated employee bearer token.

--- a/Maliev.AuthService.Application/Interfaces/ITokenIssuancePermissionClient.cs
+++ b/Maliev.AuthService.Application/Interfaces/ITokenIssuancePermissionClient.cs
@@ -1,0 +1,15 @@
+using Maliev.AuthService.Application.DTOs.IAM;
+
+namespace Maliev.AuthService.Application.Interfaces;
+
+/// <summary>Resolves service-login authority through IAM's isolated token-issuance capability boundary.</summary>
+public interface ITokenIssuancePermissionClient
+{
+    /// <summary>Resolves current permissions and roles for the target service principal.</summary>
+    /// <param name="principalId">The exact IAM principal bound into the capability and request.</param>
+    /// <param name="cancellationToken">The caller cancellation token.</param>
+    /// <returns>The authoritative IAM permission-resolution response.</returns>
+    Task<PermissionResolutionResponse> ResolvePermissionsAsync(
+        Guid principalId,
+        CancellationToken cancellationToken);
+}

--- a/Maliev.AuthService.Infrastructure/HttpClients/TokenIssuancePermissionClient.cs
+++ b/Maliev.AuthService.Infrastructure/HttpClients/TokenIssuancePermissionClient.cs
@@ -1,0 +1,80 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Maliev.AuthService.Application.DTOs.IAM;
+using Maliev.AuthService.Application.Interfaces;
+using Maliev.AuthService.Infrastructure.Security;
+using Microsoft.Extensions.Logging;
+
+namespace Maliev.AuthService.Infrastructure.HttpClients;
+
+/// <summary>Calls IAM's isolated token-issuance permission-resolution endpoint.</summary>
+public sealed class TokenIssuancePermissionClient : ITokenIssuancePermissionClient
+{
+    private const string Route = "/iam/v1/auth/token-issuance/resolve-permissions";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+    private readonly HttpClient _httpClient;
+    private readonly ITokenIssuanceCapabilitySigner _signer;
+    private readonly ILogger<TokenIssuancePermissionClient> _logger;
+
+    /// <summary>Initializes the isolated IAM client.</summary>
+    /// <param name="httpClient">The dedicated HTTP transport.</param>
+    /// <param name="signer">The Auth-only capability signer.</param>
+    /// <param name="logger">The client logger.</param>
+    public TokenIssuancePermissionClient(
+        HttpClient httpClient,
+        ITokenIssuanceCapabilitySigner signer,
+        ILogger<TokenIssuancePermissionClient> logger)
+    {
+        _httpClient = httpClient;
+        _signer = signer;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<PermissionResolutionResponse> ResolvePermissionsAsync(
+        Guid principalId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfEqual(principalId, Guid.Empty);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, Route)
+        {
+            Content = JsonContent.Create(
+                new PermissionResolutionRequest { PrincipalId = principalId.ToString("D") },
+                options: JsonOptions)
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            _signer.CreateCapability(principalId));
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning(
+                "IAM token-issuance permission resolution failed for principal {PrincipalId} with status {StatusCode}",
+                principalId,
+                (int)response.StatusCode);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<PermissionResolutionResponse>(
+            JsonOptions,
+            cancellationToken);
+        if (result is null)
+        {
+            throw new HttpRequestException("IAM token-issuance permission resolution returned an empty response.");
+        }
+
+        if (result.PrincipalId != principalId)
+        {
+            throw new HttpRequestException("IAM token-issuance permission resolution returned a different principal.");
+        }
+
+        return result;
+    }
+}

--- a/Maliev.AuthService.Infrastructure/HttpClients/TokenIssuancePermissionClient.cs
+++ b/Maliev.AuthService.Infrastructure/HttpClients/TokenIssuancePermissionClient.cs
@@ -13,6 +13,8 @@ namespace Maliev.AuthService.Infrastructure.HttpClients;
 public sealed class TokenIssuancePermissionClient : ITokenIssuancePermissionClient
 {
     private const string Route = "/iam/v1/auth/token-issuance/resolve-permissions";
+    private const string InvalidResponseMessage =
+        "IAM token-issuance permission resolution returned an invalid response.";
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
@@ -62,9 +64,18 @@ public sealed class TokenIssuancePermissionClient : ITokenIssuancePermissionClie
             response.EnsureSuccessStatusCode();
         }
 
-        var result = await response.Content.ReadFromJsonAsync<PermissionResolutionResponse>(
-            JsonOptions,
-            cancellationToken);
+        PermissionResolutionResponse? result;
+        try
+        {
+            result = await response.Content.ReadFromJsonAsync<PermissionResolutionResponse>(
+                JsonOptions,
+                cancellationToken);
+        }
+        catch (JsonException ex)
+        {
+            throw new HttpRequestException(InvalidResponseMessage, ex);
+        }
+
         if (result is null)
         {
             throw new HttpRequestException("IAM token-issuance permission resolution returned an empty response.");
@@ -73,6 +84,16 @@ public sealed class TokenIssuancePermissionClient : ITokenIssuancePermissionClie
         if (result.PrincipalId != principalId)
         {
             throw new HttpRequestException("IAM token-issuance permission resolution returned a different principal.");
+        }
+
+        if (result.Permissions is null ||
+            result.Roles is null ||
+            result.Permissions.Any(value => string.IsNullOrWhiteSpace(value)) ||
+            result.Roles.Any(value => string.IsNullOrWhiteSpace(value)) ||
+            result.ResolvedAt == default ||
+            result.CacheUntil < result.ResolvedAt)
+        {
+            throw new HttpRequestException(InvalidResponseMessage);
         }
 
         return result;

--- a/Maliev.AuthService.Infrastructure/Security/TokenIssuanceCapabilityOptions.cs
+++ b/Maliev.AuthService.Infrastructure/Security/TokenIssuanceCapabilityOptions.cs
@@ -1,0 +1,23 @@
+namespace Maliev.AuthService.Infrastructure.Security;
+
+/// <summary>Configures AuthService's isolated IAM token-issuance capability signer.</summary>
+public sealed class TokenIssuanceCapabilityOptions
+{
+    /// <summary>The configuration section containing Auth's private signing material.</summary>
+    public const string ConfigurationSection = "Auth:TokenIssuanceCapability";
+
+    /// <summary>The fixed production capability issuer.</summary>
+    public const string Issuer = "https://auth.maliev.com";
+
+    /// <summary>The sole fixed production capability audience.</summary>
+    public const string Audience = "https://iam.maliev.com/auth/token-issuance";
+
+    /// <summary>Gets or sets the explicit identifier of the active private key.</summary>
+    public string? ActiveKeyId { get; set; }
+
+    /// <summary>Gets or sets the Auth-only RSA private key in PEM format.</summary>
+    public string? PrivateKey { get; set; }
+
+    /// <summary>Gets or sets the capability lifetime in seconds.</summary>
+    public int LifetimeSeconds { get; set; } = 30;
+}

--- a/Maliev.AuthService.Infrastructure/Security/TokenIssuanceCapabilitySigner.cs
+++ b/Maliev.AuthService.Infrastructure/Security/TokenIssuanceCapabilitySigner.cs
@@ -1,0 +1,92 @@
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Maliev.AuthService.Infrastructure.Security;
+
+/// <summary>Creates exact, short-lived capabilities for IAM permission resolution.</summary>
+public interface ITokenIssuanceCapabilitySigner
+{
+    /// <summary>Creates a capability bound to one target IAM principal.</summary>
+    /// <param name="targetPrincipalId">The exact target principal.</param>
+    /// <returns>A signed compact JWT.</returns>
+    string CreateCapability(Guid targetPrincipalId);
+}
+
+/// <summary>Signs isolated IAM permission-resolution capabilities with Auth-only key material.</summary>
+public sealed class TokenIssuanceCapabilitySigner : ITokenIssuanceCapabilitySigner
+{
+    private const int MaximumLifetimeSeconds = 60;
+    private readonly TokenIssuanceCapabilityOptions _options;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initializes a capability signer.</summary>
+    /// <param name="options">The isolated signing options.</param>
+    /// <param name="timeProvider">The source of issuance time.</param>
+    public TokenIssuanceCapabilitySigner(
+        IOptions<TokenIssuanceCapabilityOptions> options,
+        TimeProvider timeProvider)
+    {
+        _options = options.Value;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc/>
+    public string CreateCapability(Guid targetPrincipalId)
+    {
+        ArgumentOutOfRangeException.ThrowIfEqual(targetPrincipalId, Guid.Empty);
+
+        if (string.IsNullOrWhiteSpace(_options.ActiveKeyId) ||
+            !string.Equals(_options.ActiveKeyId, _options.ActiveKeyId.Trim(), StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(_options.PrivateKey) ||
+            _options.LifetimeSeconds is < 1 or > MaximumLifetimeSeconds)
+        {
+            throw new InvalidOperationException("Token-issuance capability signing is not configured correctly.");
+        }
+
+        using var rsa = RSA.Create();
+        try
+        {
+            rsa.ImportFromPem(_options.PrivateKey);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new InvalidOperationException("Token-issuance capability signing key is invalid.", exception);
+        }
+        catch (CryptographicException exception)
+        {
+            throw new InvalidOperationException("Token-issuance capability signing key is invalid.", exception);
+        }
+
+        var nowSeconds = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
+        var now = DateTimeOffset.FromUnixTimeSeconds(nowSeconds);
+        var claims = new Claim[]
+        {
+            new(JwtRegisteredClaimNames.Sub, "urn:maliev:service:auth"),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("D")),
+            new(JwtRegisteredClaimNames.Iat, nowSeconds.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Integer64),
+            new("service_name", "AuthService"),
+            new("client_id", "auth-service"),
+            new("user_type", "service"),
+            new("purpose", "iam.permission-resolution"),
+            new("target_principal_id", targetPrincipalId.ToString("D")),
+            new("permissions", "iam.auth.resolve-permissions")
+        };
+        var signingKey = new RsaSecurityKey(rsa.ExportParameters(includePrivateParameters: true))
+        {
+            KeyId = _options.ActiveKeyId
+        };
+        var token = new JwtSecurityToken(
+            TokenIssuanceCapabilityOptions.Issuer,
+            TokenIssuanceCapabilityOptions.Audience,
+            claims,
+            now.UtcDateTime,
+            now.AddSeconds(_options.LifetimeSeconds).UtcDateTime,
+            new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/Maliev.AuthService.Infrastructure/Services/AuthenticationService.cs
+++ b/Maliev.AuthService.Infrastructure/Services/AuthenticationService.cs
@@ -35,6 +35,7 @@ public class AuthenticationService : IAuthenticationService
     private readonly IAccountLockoutService _accountLockoutService;
     private readonly IRateLimitService _rateLimitService;
     private readonly IIAMServiceClient _iamServiceClient;
+    private readonly ITokenIssuancePermissionClient _tokenIssuancePermissionClient;
     private readonly ILogger<AuthenticationService> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IConfiguration _configuration;
@@ -54,6 +55,7 @@ public class AuthenticationService : IAuthenticationService
         IAccountLockoutService accountLockoutService,
         IRateLimitService rateLimitService,
         IIAMServiceClient iamServiceClient,
+        ITokenIssuancePermissionClient tokenIssuancePermissionClient,
         ILogger<AuthenticationService> logger,
         IHttpClientFactory httpClientFactory,
         IConfiguration configuration,
@@ -69,6 +71,7 @@ public class AuthenticationService : IAuthenticationService
         _accountLockoutService = accountLockoutService;
         _rateLimitService = rateLimitService;
         _iamServiceClient = iamServiceClient;
+        _tokenIssuancePermissionClient = tokenIssuancePermissionClient;
         _logger = logger;
         _httpClientFactory = httpClientFactory;
         _configuration = configuration;
@@ -445,7 +448,7 @@ public class AuthenticationService : IAuthenticationService
         PermissionResolutionResponse iamResponse;
         try
         {
-            iamResponse = await _iamServiceClient.ResolvePermissionsRequiredAsync(
+            iamResponse = await _tokenIssuancePermissionClient.ResolvePermissionsAsync(
                 serviceCredential.PrincipalId.Value,
                 cancellationToken);
         }

--- a/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
@@ -12,6 +12,7 @@ using Maliev.AuthService.Tests.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 namespace Maliev.AuthService.Tests.Contract;
@@ -70,8 +71,38 @@ public class ServiceLoginContractTests : IntegrationTestBase
         Assert.Equal(JsonValueKind.Null, user.GetProperty("email").ValueKind);
         Assert.Equal(JsonValueKind.Null, user.GetProperty("profile_image_url").ValueKind);
 
-        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(
-            json.RootElement.GetProperty("access_token").GetString());
+        var accessToken = json.RootElement.GetProperty("access_token").GetString();
+        var signingRsa = Assert.IsType<RsaSecurityKey>(Factory.SigningCredentials.Key).Rsa;
+        using var publicRsa = RSA.Create();
+        var publicKeyBytes = signingRsa.ExportSubjectPublicKeyInfo();
+        publicRsa.ImportSubjectPublicKeyInfo(publicKeyBytes, out _);
+        var keyId = Convert.ToHexString(SHA256.HashData(publicKeyBytes)).ToLowerInvariant();
+        var handler = new JwtSecurityTokenHandler();
+        var principal = handler.ValidateToken(accessToken, new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = "test-issuer",
+            ValidateAudience = true,
+            ValidAudience = "test-audience",
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new RsaSecurityKey(publicRsa) { KeyId = keyId },
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero
+        }, out var validatedToken);
+        var jwt = Assert.IsType<JwtSecurityToken>(validatedToken);
+        Assert.NotNull(principal.Identity);
+        Assert.True(principal.Identity.IsAuthenticated);
+
+        using var unrelatedRsa = RSA.Create(2048);
+        Assert.Throws<SecurityTokenInvalidSignatureException>(() =>
+            handler.ValidateToken(accessToken, new TokenValidationParameters
+            {
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new RsaSecurityKey(unrelatedRsa) { KeyId = keyId },
+                ValidateLifetime = false
+            }, out _));
         Assert.False(string.IsNullOrWhiteSpace(jwt.Header.Kid));
         Assert.Equal("test-issuer", jwt.Issuer);
         Assert.Contains("test-audience", jwt.Audiences);
@@ -397,6 +428,58 @@ public class ServiceLoginContractTests : IntegrationTestBase
                 ClientSecretHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(secret)))
                     .ToLowerInvariant(),
                 ServiceName = "Orphaned API Service",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        var response = await Client.PostAsJsonAsync("/auth/v1/service/login", new
+        {
+            client_id = clientId,
+            client_secret = secret
+        });
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(
+            ["details", "error", "error_description", "errors", "locked_until"],
+            json.RootElement.EnumerateObject().Select(property => property.Name).Order());
+        Assert.Equal("service_unavailable", json.RootElement.GetProperty("error").GetString());
+        Assert.Equal(
+            "Service authentication is temporarily unavailable",
+            json.RootElement.GetProperty("error_description").GetString());
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("details").ValueKind);
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("errors").ValueKind);
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("locked_until").ValueKind);
+        Assert.False(json.RootElement.TryGetProperty("access_token", out _));
+        Assert.Equal(1, Factory.TokenIssuanceResolutionCalls);
+        Assert.Equal(0, Factory.LegacyIamResolutionCalls);
+    }
+
+    [Theory]
+    [InlineData("33333333-3333-3333-3333-333333333333", "null-permissions")]
+    [InlineData("44444444-4444-4444-4444-444444444444", "null-roles")]
+    [InlineData("55555555-5555-5555-5555-555555555555", "null-permission-element")]
+    [InlineData("66666666-6666-6666-6666-666666666666", "null-role-element")]
+    public async Task POST_V1_Auth_Service_Login_MalformedIamAuthority_ReturnsSanitized503WithoutToken(
+        string principalId,
+        string clientSuffix)
+    {
+        await CleanDatabaseAsync();
+        var clientId = $"service-dev-{clientSuffix}-api";
+        var secret = $"dummy_{clientSuffix}_secret_345";
+        await using (var context = Factory.GetDbContext())
+        {
+            context.ServiceCredentials.Add(new ServiceCredential
+            {
+                Id = Guid.NewGuid(),
+                ClientId = clientId,
+                PrincipalId = Guid.Parse(principalId),
+                ClientSecretHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(secret)))
+                    .ToLowerInvariant(),
+                ServiceName = "Malformed IAM Response Service",
                 IsActive = true,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow

--- a/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
@@ -47,6 +47,10 @@ public class ServiceLoginContractTests : IntegrationTestBase
         var content = await response.Content.ReadAsStringAsync();
         var json = JsonDocument.Parse(content);
 
+        Assert.Equal(
+            ["access_token", "expires_in", "token_type", "user"],
+            json.RootElement.EnumerateObject().Select(property => property.Name).Order());
+
         Assert.NotNull(json.RootElement.GetProperty("access_token").GetString());
         Assert.NotEmpty(json.RootElement.GetProperty("access_token").GetString()!);
         Assert.Equal("Bearer", json.RootElement.GetProperty("token_type").GetString());
@@ -54,6 +58,17 @@ public class ServiceLoginContractTests : IntegrationTestBase
 
         // Service tokens should not have refresh tokens
         Assert.False(json.RootElement.TryGetProperty("refresh_token", out _));
+        var user = json.RootElement.GetProperty("user");
+        Assert.Equal(
+            ["customer_id", "email", "name", "principal_id", "profile_image_url", "user_id", "user_type"],
+            user.EnumerateObject().Select(property => property.Name).Order());
+        Assert.Equal("service-dev-customer-api", user.GetProperty("user_id").GetString());
+        Assert.Equal("11111111-1111-1111-1111-111111111111", user.GetProperty("principal_id").GetString());
+        Assert.Equal("service", user.GetProperty("user_type").GetString());
+        Assert.Equal("Customer API Service", user.GetProperty("name").GetString());
+        Assert.Equal(JsonValueKind.Null, user.GetProperty("customer_id").ValueKind);
+        Assert.Equal(JsonValueKind.Null, user.GetProperty("email").ValueKind);
+        Assert.Equal(JsonValueKind.Null, user.GetProperty("profile_image_url").ValueKind);
 
         var jwt = new JwtSecurityTokenHandler().ReadJwtToken(
             json.RootElement.GetProperty("access_token").GetString());
@@ -68,6 +83,31 @@ public class ServiceLoginContractTests : IntegrationTestBase
         Assert.Equal("Customer API Service", jwt.Claims.Single(c => c.Type == "service_name").Value);
         Assert.DoesNotContain(jwt.Claims, claim =>
             claim.Type == "permissions" && claim.Value == "*");
+        Assert.Equal(1, Factory.TokenIssuanceResolutionCalls);
+        Assert.Equal(0, Factory.LegacyIamResolutionCalls);
+
+        using var permissionRequest = JsonDocument.Parse(Factory.LastTokenIssuanceRequestBody!);
+        Assert.Equal(
+            ["principalId"],
+            permissionRequest.RootElement.EnumerateObject().Select(property => property.Name));
+        Assert.Equal(
+            "11111111-1111-1111-1111-111111111111",
+            permissionRequest.RootElement.GetProperty("principalId").GetString());
+
+        var capability = new JwtSecurityTokenHandler().ReadJwtToken(Factory.LastTokenIssuanceAuthorization);
+        Assert.Equal("auth-capability-test-key", capability.Header.Kid);
+        Assert.Equal([TokenIssuanceCapabilityOptions.Audience], capability.Audiences);
+        Assert.Equal(
+            "iam.permission-resolution",
+            capability.Claims.Single(claim => claim.Type == "purpose").Value);
+        Assert.Equal(
+            "11111111-1111-1111-1111-111111111111",
+            capability.Claims.Single(claim => claim.Type == "target_principal_id").Value);
+        Assert.Equal(
+            ["iam.auth.resolve-permissions"],
+            capability.Claims.Where(claim => claim.Type == "permissions").Select(claim => claim.Value));
+        Assert.DoesNotContain(capability.Claims, claim => claim.Type is "role" or "roles");
+        Assert.DoesNotContain(capability.Claims, claim => claim.Value == "*");
     }
 
     [Fact]
@@ -326,8 +366,19 @@ public class ServiceLoginContractTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
         var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(
+            ["details", "error", "error_description", "errors", "locked_until"],
+            json.RootElement.EnumerateObject().Select(property => property.Name).Order());
         Assert.Equal("service_unavailable", json.RootElement.GetProperty("error").GetString());
+        Assert.Equal(
+            "Service authentication is temporarily unavailable",
+            json.RootElement.GetProperty("error_description").GetString());
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("details").ValueKind);
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("errors").ValueKind);
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("locked_until").ValueKind);
         Assert.False(json.RootElement.TryGetProperty("access_token", out _));
+        Assert.Equal(0, Factory.TokenIssuanceResolutionCalls);
+        Assert.Equal(0, Factory.LegacyIamResolutionCalls);
     }
 
     [Fact]
@@ -361,7 +412,59 @@ public class ServiceLoginContractTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
         var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(
+            ["details", "error", "error_description", "errors", "locked_until"],
+            json.RootElement.EnumerateObject().Select(property => property.Name).Order());
         Assert.Equal("service_unavailable", json.RootElement.GetProperty("error").GetString());
+        Assert.Equal(
+            "Service authentication is temporarily unavailable",
+            json.RootElement.GetProperty("error_description").GetString());
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("details").ValueKind);
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("errors").ValueKind);
+        Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("locked_until").ValueKind);
         Assert.False(json.RootElement.TryGetProperty("access_token", out _));
+        Assert.Equal(1, Factory.TokenIssuanceResolutionCalls);
+        Assert.Equal(0, Factory.LegacyIamResolutionCalls);
+    }
+
+    [Fact]
+    public async Task POST_V1_Auth_Service_Login_MissingCapabilityKey_ReturnsSanitized503WithoutToken()
+    {
+        await CleanDatabaseAsync();
+        using var scope = Factory.Services.CreateScope();
+        var options = scope.ServiceProvider
+            .GetRequiredService<IOptions<TokenIssuanceCapabilityOptions>>()
+            .Value;
+        var originalPrivateKey = options.PrivateKey;
+        try
+        {
+            options.PrivateKey = null;
+
+            var response = await Client.PostAsJsonAsync("/auth/v1/service/login", new
+            {
+                client_id = "service-dev-customer-api",
+                client_secret = TestConstants.DummyValidServiceSecret
+            });
+
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+            var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            Assert.Equal(
+                ["details", "error", "error_description", "errors", "locked_until"],
+                json.RootElement.EnumerateObject().Select(property => property.Name).Order());
+            Assert.Equal("service_unavailable", json.RootElement.GetProperty("error").GetString());
+            Assert.Equal(
+                "Service authentication is temporarily unavailable",
+                json.RootElement.GetProperty("error_description").GetString());
+            Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("details").ValueKind);
+            Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("errors").ValueKind);
+            Assert.Equal(JsonValueKind.Null, json.RootElement.GetProperty("locked_until").ValueKind);
+            Assert.False(json.RootElement.TryGetProperty("access_token", out _));
+            Assert.Equal(0, Factory.TokenIssuanceResolutionCalls);
+            Assert.Equal(0, Factory.LegacyIamResolutionCalls);
+        }
+        finally
+        {
+            options.PrivateKey = originalPrivateKey;
+        }
     }
 }

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -25,6 +25,14 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
 
     public static readonly Guid NonexistentIamPrincipalId =
         Guid.Parse("22222222-2222-2222-2222-222222222222");
+    public static readonly Guid NullPermissionsIamPrincipalId =
+        Guid.Parse("33333333-3333-3333-3333-333333333333");
+    public static readonly Guid NullRolesIamPrincipalId =
+        Guid.Parse("44444444-4444-4444-4444-444444444444");
+    public static readonly Guid NullPermissionElementIamPrincipalId =
+        Guid.Parse("55555555-5555-5555-5555-555555555555");
+    public static readonly Guid NullRoleElementIamPrincipalId =
+        Guid.Parse("66666666-6666-6666-6666-666666666666");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
     public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
@@ -349,6 +357,26 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                     StringComparison.OrdinalIgnoreCase))
                 {
                     return new HttpResponseMessage(HttpStatusCode.NotFound);
+                }
+
+                var malformedAuthorityJson = principalId switch
+                {
+                    var value when string.Equals(value, NullPermissionsIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":null,"roles":[],"resolvedAt":"2026-07-16T04:00:00Z"}""",
+                    var value when string.Equals(value, NullRolesIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":null,"resolvedAt":"2026-07-16T04:00:00Z"}""",
+                    var value when string.Equals(value, NullPermissionElementIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":[null],"roles":[],"resolvedAt":"2026-07-16T04:00:00Z"}""",
+                    var value when string.Equals(value, NullRoleElementIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[null],"resolvedAt":"2026-07-16T04:00:00Z"}""",
+                    _ => null
+                };
+                if (malformedAuthorityJson is not null)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(malformedAuthorityJson)
+                    };
                 }
 
                 var response = new

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -18,17 +18,29 @@ namespace Maliev.AuthService.Tests.Contract;
 public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, AuthDbContext>
 {
     private int _iamResolutionCalls;
+    private int _legacyIamResolutionCalls;
+    private int _tokenIssuanceResolutionCalls;
+    private string? _lastTokenIssuanceAuthorization;
+    private string? _lastTokenIssuanceRequestBody;
 
     public static readonly Guid NonexistentIamPrincipalId =
         Guid.Parse("22222222-2222-2222-2222-222222222222");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
+    public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
+    public int TokenIssuanceResolutionCalls => Volatile.Read(ref _tokenIssuanceResolutionCalls);
+    public string? LastTokenIssuanceAuthorization => Volatile.Read(ref _lastTokenIssuanceAuthorization);
+    public string? LastTokenIssuanceRequestBody => Volatile.Read(ref _lastTokenIssuanceRequestBody);
     /// <summary>
     /// Override CleanDatabaseAsync to seed required test data after cleanup and clear Redis
     /// </summary>
     public new async Task CleanDatabaseAsync()
     {
         Interlocked.Exchange(ref _iamResolutionCalls, 0);
+        Interlocked.Exchange(ref _legacyIamResolutionCalls, 0);
+        Interlocked.Exchange(ref _tokenIssuanceResolutionCalls, 0);
+        Interlocked.Exchange(ref _lastTokenIssuanceAuthorization, null);
+        Interlocked.Exchange(ref _lastTokenIssuanceRequestBody, null);
         await base.CleanDatabaseAsync();
         await ClearRedisAsync();
         await SeedTestDataAsync();
@@ -107,6 +119,12 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
             var privateKeyPem = rsa.ExportPkcs8PrivateKeyPem();
             var privateKeyBase64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(privateKeyPem));
             Environment.SetEnvironmentVariable("Jwt__PrivateKey", privateKeyBase64);
+            Environment.SetEnvironmentVariable(
+                "Auth__TokenIssuanceCapability__ActiveKeyId",
+                "auth-capability-test-key");
+            Environment.SetEnvironmentVariable(
+                "Auth__TokenIssuanceCapability__PrivateKey",
+                privateKeyPem);
 
             // Export public key for token validation
             var publicKeyPem = rsa.ExportSubjectPublicKeyInfoPem();  // Use SubjectPublicKeyInfo format
@@ -302,9 +320,55 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
             }
 
             // Mock IAM resolution response
+            if (request.RequestUri?.PathAndQuery.Contains("/iam/v1/auth/token-issuance/resolve-permissions") == true)
+            {
+                Interlocked.Increment(ref _owner._iamResolutionCalls);
+                Interlocked.Increment(ref _owner._tokenIssuanceResolutionCalls);
+                Interlocked.Exchange(
+                    ref _owner._lastTokenIssuanceAuthorization,
+                    request.Headers.Authorization?.Parameter);
+                if (request.RequestUri.Port == 5101)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                }
+
+                string? principalId = null;
+                if (request.Content != null)
+                {
+                    var requestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+                    Interlocked.Exchange(ref _owner._lastTokenIssuanceRequestBody, requestBody);
+                    var jsonDoc = JsonDocument.Parse(requestBody);
+                    if (jsonDoc.RootElement.TryGetProperty("PrincipalId", out var principalIdElement) ||
+                        jsonDoc.RootElement.TryGetProperty("principalId", out principalIdElement))
+                        principalId = principalIdElement.GetString();
+                }
+
+                if (string.Equals(
+                    principalId,
+                    NonexistentIamPrincipalId.ToString(),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.NotFound);
+                }
+
+                var response = new
+                {
+                    principalId = principalId ?? Guid.NewGuid().ToString(),
+                    permissions = new[] { "auth.api_keys.manage", "auth.users.read" },
+                    roles = new[] { "security_admin" },
+                    resolvedAt = DateTime.UtcNow
+                };
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(response)
+                };
+            }
+
             if (request.RequestUri?.PathAndQuery.Contains("/iam/v1/auth/resolve-permissions") == true)
             {
                 Interlocked.Increment(ref _owner._iamResolutionCalls);
+                Interlocked.Increment(ref _owner._legacyIamResolutionCalls);
                 if (request.RequestUri.Port == 5101)
                 {
                     return new HttpResponseMessage(HttpStatusCode.InternalServerError);

--- a/Maliev.AuthService.Tests/Unit/AuthenticationServiceTests.cs
+++ b/Maliev.AuthService.Tests/Unit/AuthenticationServiceTests.cs
@@ -30,6 +30,7 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
     private readonly Mock<IAccountLockoutService> _accountLockoutServiceMock;
     private readonly Mock<IRateLimitService> _rateLimitServiceMock;
     private readonly Mock<IIAMServiceClient> _iamClientMock;
+    private readonly Mock<ITokenIssuancePermissionClient> _tokenIssuancePermissionClientMock;
     private readonly Mock<ILogger<AuthenticationService>> _loggerMock;
     private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
     private readonly Mock<IConfiguration> _configurationMock;
@@ -51,6 +52,7 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
         _accountLockoutServiceMock = new Mock<IAccountLockoutService>();
         _rateLimitServiceMock = new Mock<IRateLimitService>();
         _iamClientMock = new Mock<IIAMServiceClient>();
+        _tokenIssuancePermissionClientMock = new Mock<ITokenIssuancePermissionClient>();
         _loggerMock = new Mock<ILogger<AuthenticationService>>();
         _httpClientFactoryMock = new Mock<IHttpClientFactory>();
         _configurationMock = new Mock<IConfiguration>();
@@ -82,6 +84,7 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
             _accountLockoutServiceMock.Object,
             _rateLimitServiceMock.Object,
             _iamClientMock.Object,
+            _tokenIssuancePermissionClientMock.Object,
             _loggerMock.Object,
             _httpClientFactoryMock.Object,
             _configurationMock.Object,
@@ -729,6 +732,7 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
             _accountLockoutServiceMock.Object,
             _rateLimitServiceMock.Object,
             _iamClientMock.Object,
+            _tokenIssuancePermissionClientMock.Object,
             _loggerMock.Object,
             _httpClientFactoryMock.Object,
             configuration,
@@ -930,8 +934,8 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
     [Fact]
     public async Task AuthenticateServiceAsync_ValidCredentials_ReturnsToken()
     {
-        _iamClientMock
-            .Setup(client => client.ResolvePermissionsRequiredAsync(
+        _tokenIssuancePermissionClientMock
+            .Setup(client => client.ResolvePermissionsAsync(
                 Guid.Parse("11111111-1111-1111-1111-111111111111"),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PermissionResolutionResponse
@@ -961,6 +965,9 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
         Assert.True(result.Success);
         Assert.Equal("server-issued-token", result.Response?.AccessToken);
         Assert.Equal(900, result.Response?.ExpiresIn);
+        _iamClientMock.Verify(client => client.ResolvePermissionsRequiredAsync(
+            It.IsAny<Guid>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -1000,11 +1007,40 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
     [Fact]
     public async Task AuthenticateServiceAsync_IamUnavailable_ReturnsServiceUnavailableWithoutToken()
     {
-        _iamClientMock
-            .Setup(client => client.ResolvePermissionsRequiredAsync(
+        _tokenIssuancePermissionClientMock
+            .Setup(client => client.ResolvePermissionsAsync(
                 It.IsAny<Guid>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new HttpRequestException("IAM unavailable"));
+
+        var result = await _service!.AuthenticateServiceAsync(
+            new ServiceLoginRequest
+            {
+                ClientId = "service-dev-customer-api",
+                ClientSecret = TestConstants.DummyValidServiceSecret
+            },
+            "127.0.0.1",
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal("service_unavailable", result.ErrorCode);
+        Assert.Null(result.Response);
+        _tokenGeneratorMock.Verify(generator => generator.GenerateServiceAccessTokenAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<IEnumerable<string>>(),
+            It.IsAny<IEnumerable<string>>(),
+            It.IsAny<Guid?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AuthenticateServiceAsync_IamTimeout_ReturnsServiceUnavailableWithoutToken()
+    {
+        _tokenIssuancePermissionClientMock
+            .Setup(client => client.ResolvePermissionsAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("IAM request timed out"));
 
         var result = await _service!.AuthenticateServiceAsync(
             new ServiceLoginRequest
@@ -1031,8 +1067,8 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
     {
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
-        _iamClientMock
-            .Setup(client => client.ResolvePermissionsRequiredAsync(
+        _tokenIssuancePermissionClientMock
+            .Setup(client => client.ResolvePermissionsAsync(
                 It.IsAny<Guid>(),
                 cancellation.Token))
             .ThrowsAsync(new OperationCanceledException(cancellation.Token));
@@ -1061,8 +1097,8 @@ public class AuthenticationServiceTests : IClassFixture<TestDatabaseFixture>, IA
     public async Task AuthenticateServiceAsync_IamReturnsWildcardAuthority_ReturnsServiceUnavailableWithoutToken(
         bool wildcardIsPermission)
     {
-        _iamClientMock
-            .Setup(client => client.ResolvePermissionsRequiredAsync(
+        _tokenIssuancePermissionClientMock
+            .Setup(client => client.ResolvePermissionsAsync(
                 It.IsAny<Guid>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PermissionResolutionResponse

--- a/Maliev.AuthService.Tests/Unit/IAMServiceClientAdditionalTests.cs
+++ b/Maliev.AuthService.Tests/Unit/IAMServiceClientAdditionalTests.cs
@@ -15,6 +15,43 @@ public class IAMServiceClientAdditionalTests
     }
 
     [Fact]
+    public void Program_TokenIssuanceClient_IsBoundedAndHasNoLegacyAuthenticationOrRetryHandler()
+    {
+        var programSource = File.ReadAllText(FindProgramSource());
+        var start = programSource.IndexOf(
+            "AddHttpClient<ITokenIssuancePermissionClient, TokenIssuancePermissionClient>",
+            StringComparison.Ordinal);
+        var end = start >= 0
+            ? programSource.IndexOf(
+                "// Dedicated human-authorized client",
+                start,
+                StringComparison.Ordinal)
+            : -1;
+
+        Assert.True(start >= 0);
+        Assert.True(end > start);
+        var registration = programSource[start..end];
+        Assert.Contains("client.Timeout = TimeSpan.FromSeconds(10)", registration, StringComparison.Ordinal);
+        Assert.Contains(".AddServiceDiscovery()", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain(".AddHttpMessageHandler", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain(".AddPolicyHandler", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain(".AddResilienceHandler", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain("ServiceAccountAuthenticationHandler", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain("IServiceAccountTokenProvider", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain("AuthServiceTokenProvider", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddStandardResilienceHandler", registration, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddTransientHttpErrorPolicy", registration, StringComparison.Ordinal);
+
+        var optionsStart = programSource.IndexOf(
+            "AddOptions<TokenIssuanceCapabilityOptions>",
+            StringComparison.Ordinal);
+        Assert.True(optionsStart >= 0);
+        var optionsRegistration = programSource[optionsStart..start];
+        Assert.DoesNotContain("ValidateOnStart", optionsRegistration, StringComparison.Ordinal);
+        Assert.DoesNotContain("Jwt", optionsRegistration, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PermissionResolutionResponse_SetsPropertiesCorrectly()
     {
         var principalId = Guid.NewGuid();

--- a/Maliev.AuthService.Tests/Unit/TokenIssuanceCapabilitySignerTests.cs
+++ b/Maliev.AuthService.Tests/Unit/TokenIssuanceCapabilitySignerTests.cs
@@ -1,0 +1,141 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
+using Maliev.AuthService.Infrastructure.Security;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+public sealed class TokenIssuanceCapabilitySignerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 16, 4, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void CreateCapability_ValidConfiguration_ProducesExactTargetBoundClaims()
+    {
+        using var rsa = RSA.Create(2048);
+        var options = new TokenIssuanceCapabilityOptions
+        {
+            ActiveKeyId = "auth-capability-2026-07",
+            PrivateKey = rsa.ExportRSAPrivateKeyPem()
+        };
+        var signer = new TokenIssuanceCapabilitySigner(
+            Options.Create(options),
+            new FixedTimeProvider(Now));
+        var target = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+        var encoded = signer.CreateCapability(target);
+
+        var token = new JwtSecurityTokenHandler().ReadJwtToken(encoded);
+        Assert.Equal(SecurityAlgorithms.RsaSha256, token.Header.Alg);
+        Assert.Equal(options.ActiveKeyId, token.Header.Kid);
+        Assert.Equal(TokenIssuanceCapabilityOptions.Issuer, token.Issuer);
+        Assert.Equal([TokenIssuanceCapabilityOptions.Audience], token.Audiences);
+        AssertSingle(token, JwtRegisteredClaimNames.Sub, "urn:maliev:service:auth");
+        AssertSingle(token, "service_name", "AuthService");
+        AssertSingle(token, "client_id", "auth-service");
+        AssertSingle(token, "user_type", "service");
+        AssertSingle(token, "purpose", "iam.permission-resolution");
+        AssertSingle(token, "target_principal_id", target.ToString("D"));
+        AssertSingle(token, "permissions", "iam.auth.resolve-permissions");
+        Assert.DoesNotContain(token.Claims, claim => claim.Type is "permission" or "role" or "roles");
+
+        var jti = Assert.Single(token.Claims, claim => claim.Type == JwtRegisteredClaimNames.Jti).Value;
+        Assert.True(Guid.TryParseExact(jti, "D", out _));
+        var iat = long.Parse(Assert.Single(token.Claims, claim => claim.Type == JwtRegisteredClaimNames.Iat).Value);
+        var nbf = long.Parse(Assert.Single(token.Claims, claim => claim.Type == JwtRegisteredClaimNames.Nbf).Value);
+        var exp = long.Parse(Assert.Single(token.Claims, claim => claim.Type == JwtRegisteredClaimNames.Exp).Value);
+        Assert.Equal(Now.ToUnixTimeSeconds(), iat);
+        Assert.Equal(iat, nbf);
+        Assert.Equal(30, exp - iat);
+    }
+
+    [Fact]
+    public void CreateCapability_Twice_UsesUniqueCanonicalTokenIdentifiers()
+    {
+        using var rsa = RSA.Create(2048);
+        var signer = new TokenIssuanceCapabilitySigner(
+            Options.Create(new TokenIssuanceCapabilityOptions
+            {
+                ActiveKeyId = "active-key",
+                PrivateKey = rsa.ExportPkcs8PrivateKeyPem()
+            }),
+            new FixedTimeProvider(Now));
+
+        var first = new JwtSecurityTokenHandler().ReadJwtToken(signer.CreateCapability(Guid.NewGuid()));
+        var second = new JwtSecurityTokenHandler().ReadJwtToken(signer.CreateCapability(Guid.NewGuid()));
+        var firstJti = first.Claims.Single(claim => claim.Type == JwtRegisteredClaimNames.Jti).Value;
+        var secondJti = second.Claims.Single(claim => claim.Type == JwtRegisteredClaimNames.Jti).Value;
+
+        Assert.NotEqual(firstJti, secondJti);
+        Assert.Equal(Guid.Parse(firstJti).ToString("D"), firstJti);
+        Assert.Equal(Guid.Parse(secondJti).ToString("D"), secondJti);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(61)]
+    public void CreateCapability_InvalidLifetime_FailsClosed(int lifetimeSeconds)
+    {
+        using var rsa = RSA.Create(2048);
+        var signer = new TokenIssuanceCapabilitySigner(
+            Options.Create(new TokenIssuanceCapabilityOptions
+            {
+                ActiveKeyId = "active-key",
+                PrivateKey = rsa.ExportRSAPrivateKeyPem(),
+                LifetimeSeconds = lifetimeSeconds
+            }),
+            new FixedTimeProvider(Now));
+
+        Assert.Throws<InvalidOperationException>(() => signer.CreateCapability(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void CreateCapability_MaximumLifetime_ProducesSixtySecondCapability()
+    {
+        using var rsa = RSA.Create(2048);
+        var signer = new TokenIssuanceCapabilitySigner(
+            Options.Create(new TokenIssuanceCapabilityOptions
+            {
+                ActiveKeyId = "active-key",
+                PrivateKey = rsa.ExportRSAPrivateKeyPem(),
+                LifetimeSeconds = 60
+            }),
+            new FixedTimeProvider(Now));
+
+        var token = new JwtSecurityTokenHandler().ReadJwtToken(signer.CreateCapability(Guid.NewGuid()));
+        var issuedAt = long.Parse(token.Claims.Single(claim => claim.Type == JwtRegisteredClaimNames.Iat).Value);
+        var expiresAt = long.Parse(token.Claims.Single(claim => claim.Type == JwtRegisteredClaimNames.Exp).Value);
+
+        Assert.Equal(60, expiresAt - issuedAt);
+    }
+
+    [Theory]
+    [InlineData(null, "not-a-key")]
+    [InlineData("", "not-a-key")]
+    [InlineData("active-key", null)]
+    [InlineData("active-key", "not-a-key")]
+    public void CreateCapability_MissingOrInvalidSigningConfiguration_FailsAtCallTime(
+        string? activeKeyId,
+        string? privateKey)
+    {
+        var signer = new TokenIssuanceCapabilitySigner(
+            Options.Create(new TokenIssuanceCapabilityOptions
+            {
+                ActiveKeyId = activeKeyId,
+                PrivateKey = privateKey
+            }),
+            new FixedTimeProvider(Now));
+
+        Assert.Throws<InvalidOperationException>(() => signer.CreateCapability(Guid.NewGuid()));
+    }
+
+    private static void AssertSingle(JwtSecurityToken token, string type, string value) =>
+        Assert.Equal(value, Assert.Single(token.Claims, claim => claim.Type == type).Value);
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/Maliev.AuthService.Tests/Unit/TokenIssuanceCapabilitySignerTests.cs
+++ b/Maliev.AuthService.Tests/Unit/TokenIssuanceCapabilitySignerTests.cs
@@ -27,7 +27,22 @@ public sealed class TokenIssuanceCapabilitySignerTests
 
         var encoded = signer.CreateCapability(target);
 
-        var token = new JwtSecurityTokenHandler().ReadJwtToken(encoded);
+        using var publicRsa = RSA.Create();
+        publicRsa.ImportSubjectPublicKeyInfo(rsa.ExportSubjectPublicKeyInfo(), out _);
+        var handler = new JwtSecurityTokenHandler();
+        var principal = handler.ValidateToken(encoded, new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = TokenIssuanceCapabilityOptions.Issuer,
+            ValidateAudience = true,
+            ValidAudience = TokenIssuanceCapabilityOptions.Audience,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new RsaSecurityKey(publicRsa),
+            ValidateLifetime = false
+        }, out var validatedToken);
+        var token = Assert.IsType<JwtSecurityToken>(validatedToken);
+        Assert.NotNull(principal.Identity);
+        Assert.True(principal.Identity.IsAuthenticated);
         Assert.Equal(SecurityAlgorithms.RsaSha256, token.Header.Alg);
         Assert.Equal(options.ActiveKeyId, token.Header.Kid);
         Assert.Equal(TokenIssuanceCapabilityOptions.Issuer, token.Issuer);
@@ -49,6 +64,34 @@ public sealed class TokenIssuanceCapabilitySignerTests
         Assert.Equal(Now.ToUnixTimeSeconds(), iat);
         Assert.Equal(iat, nbf);
         Assert.Equal(30, exp - iat);
+    }
+
+    [Fact]
+    public void CreateCapability_UnrelatedPublicKey_RejectsSignature()
+    {
+        using var signingRsa = RSA.Create(2048);
+        using var unrelatedRsa = RSA.Create(2048);
+        var signer = new TokenIssuanceCapabilitySigner(
+            Options.Create(new TokenIssuanceCapabilityOptions
+            {
+                ActiveKeyId = "active-key",
+                PrivateKey = signingRsa.ExportPkcs8PrivateKeyPem()
+            }),
+            new FixedTimeProvider(Now));
+        var encoded = signer.CreateCapability(Guid.NewGuid());
+        var unrelatedKey = new RsaSecurityKey(unrelatedRsa) { KeyId = "active-key" };
+
+        var exception = Assert.Throws<SecurityTokenInvalidSignatureException>(() =>
+            new JwtSecurityTokenHandler().ValidateToken(encoded, new TokenValidationParameters
+            {
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = unrelatedKey,
+                ValidateLifetime = false
+            }, out _));
+
+        Assert.Contains("signature", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/Maliev.AuthService.Tests/Unit/TokenIssuancePermissionClientTests.cs
+++ b/Maliev.AuthService.Tests/Unit/TokenIssuancePermissionClientTests.cs
@@ -74,8 +74,11 @@ public sealed class TokenIssuancePermissionClientTests
             Content = new StringContent("{not-json")
         }));
 
-        await Assert.ThrowsAnyAsync<Exception>(() =>
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
             client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+
+        Assert.Equal("IAM token-issuance permission resolution returned an invalid response.", exception.Message);
+        Assert.IsType<JsonException>(exception.InnerException);
     }
 
     [Fact]
@@ -94,6 +97,78 @@ public sealed class TokenIssuancePermissionClientTests
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
             client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("permissions", "null")]
+    [InlineData("roles", "null")]
+    [InlineData("permissions", "[null]")]
+    [InlineData("roles", "[null]")]
+    [InlineData("permissions", "[\"\"]")]
+    [InlineData("roles", "[\"   \"]")]
+    public async Task ResolvePermissionsAsync_InvalidAuthorityCollections_ThrowsControlledClientFailure(
+        string propertyName,
+        string propertyValue)
+    {
+        var permissions = propertyName == "permissions" ? propertyValue : "[]";
+        var roles = propertyName == "roles" ? propertyValue : "[]";
+        var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                $$"""
+                {
+                  "principalId": "{{PrincipalId:D}}",
+                  "permissions": {{permissions}},
+                  "roles": {{roles}},
+                  "resolvedAt": "2026-07-16T04:00:00Z"
+                }
+                """)
+        }));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+
+        Assert.Equal("IAM token-issuance permission resolution returned an invalid response.", exception.Message);
+    }
+
+    [Fact]
+    public async Task ResolvePermissionsAsync_MissingResolvedTimestamp_ThrowsControlledClientFailure()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new
+            {
+                principalId = PrincipalId,
+                permissions = Array.Empty<string>(),
+                roles = Array.Empty<string>()
+            })
+        }));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+
+        Assert.Equal("IAM token-issuance permission resolution returned an invalid response.", exception.Message);
+    }
+
+    [Fact]
+    public async Task ResolvePermissionsAsync_CacheExpiryBeforeResolution_ThrowsControlledClientFailure()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new
+            {
+                principalId = PrincipalId,
+                permissions = Array.Empty<string>(),
+                roles = Array.Empty<string>(),
+                resolvedAt = new DateTime(2026, 7, 16, 4, 0, 0, DateTimeKind.Utc),
+                cacheUntil = new DateTime(2026, 7, 16, 3, 59, 59, DateTimeKind.Utc)
+            })
+        }));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+
+        Assert.Equal("IAM token-issuance permission resolution returned an invalid response.", exception.Message);
     }
 
     [Fact]

--- a/Maliev.AuthService.Tests/Unit/TokenIssuancePermissionClientTests.cs
+++ b/Maliev.AuthService.Tests/Unit/TokenIssuancePermissionClientTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Maliev.AuthService.Infrastructure.HttpClients;
+using Maliev.AuthService.Infrastructure.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Maliev.AuthService.Tests.Unit;
+
+public sealed class TokenIssuancePermissionClientTests
+{
+    private static readonly Guid PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task ResolvePermissionsAsync_ValidResponse_UsesOnlyAdditiveRouteAndTargetCoupledToken()
+    {
+        HttpRequestMessage? captured = null;
+        var signer = new RecordingSigner();
+        using var httpClient = new HttpClient(new DelegatingTestHandler(async (request, cancellationToken) =>
+        {
+            captured = request;
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            using var json = JsonDocument.Parse(body);
+            Assert.Equal(["principalId"], json.RootElement.EnumerateObject().Select(property => property.Name));
+            Assert.Equal(PrincipalId.ToString("D"), json.RootElement.GetProperty("principalId").GetString());
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new
+                {
+                    principalId = PrincipalId,
+                    permissions = new[] { "customer.customers.read" },
+                    roles = new[] { "service.customer" },
+                    resolvedAt = DateTime.UtcNow,
+                    cacheUntil = (DateTime?)null
+                })
+            };
+        }))
+        {
+            BaseAddress = new Uri("https://iam.test"),
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+        var client = new TokenIssuancePermissionClient(httpClient, signer, NullLogger<TokenIssuancePermissionClient>.Instance);
+
+        var response = await client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Post, captured.Method);
+        Assert.Equal("/iam/v1/auth/token-issuance/resolve-permissions", captured.RequestUri!.AbsolutePath);
+        Assert.Equal("Bearer", captured.Headers.Authorization!.Scheme);
+        Assert.Equal("capability-token", captured.Headers.Authorization.Parameter);
+        Assert.Equal(PrincipalId, signer.TargetPrincipalId);
+        Assert.Equal(PrincipalId, response.PrincipalId);
+        Assert.Equal(["customer.customers.read"], response.Permissions);
+        Assert.Equal(["service.customer"], response.Roles);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task ResolvePermissionsAsync_NonSuccess_Throws(HttpStatusCode statusCode)
+    {
+        var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(statusCode)));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ResolvePermissionsAsync_MalformedResponse_Throws()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{not-json")
+        }));
+
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ResolvePermissionsAsync_MismatchedPrincipal_Throws()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new
+            {
+                principalId = Guid.NewGuid(),
+                permissions = Array.Empty<string>(),
+                roles = Array.Empty<string>(),
+                resolvedAt = DateTime.UtcNow
+            })
+        }));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ResolvePermissionsAsync_CallerCancellation_Propagates()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var client = CreateClient((_, token) => Task.FromCanceled<HttpResponseMessage>(token));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.ResolvePermissionsAsync(PrincipalId, cancellation.Token));
+    }
+
+    [Fact]
+    public async Task ResolvePermissionsAsync_HttpTimeout_ThrowsWithoutCancellingCallerToken()
+    {
+        using var httpClient = new HttpClient(new DelegatingTestHandler(
+            async (_, token) =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }))
+        {
+            BaseAddress = new Uri("https://iam.test"),
+            Timeout = TimeSpan.FromMilliseconds(20)
+        };
+        var client = new TokenIssuancePermissionClient(
+            httpClient,
+            new RecordingSigner(),
+            NullLogger<TokenIssuancePermissionClient>.Instance);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
+    }
+
+    private static TokenIssuancePermissionClient CreateClient(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync)
+    {
+        var httpClient = new HttpClient(new DelegatingTestHandler(sendAsync))
+        {
+            BaseAddress = new Uri("https://iam.test"),
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+        return new TokenIssuancePermissionClient(
+            httpClient,
+            new RecordingSigner(),
+            NullLogger<TokenIssuancePermissionClient>.Instance);
+    }
+
+    private sealed class RecordingSigner : ITokenIssuanceCapabilitySigner
+    {
+        public Guid? TargetPrincipalId { get; private set; }
+
+        public string CreateCapability(Guid targetPrincipalId)
+        {
+            TargetPrincipalId = targetPrincipalId;
+            return "capability-token";
+        }
+    }
+
+    private sealed class DelegatingTestHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => sendAsync(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- move service-login permission resolution to the dedicated IAM token-issuance capability endpoint
- sign target-bound Auth-only RS256 capabilities with exact claims, kid, issuer, audience, and bounded lifetime
- keep all other IAM authentication flows on their existing client
- reject malformed or mismatched IAM authority responses before token issuance and map failures to sanitized 503

## Validation
- controller focused rerun: 46/46 passed
- focused client/signer: 25/25 passed
- hosted service-login selection: 10/10 passed
- service layer: 8/8 passed
- full Release suite: 404/404 passed
- Release build: 0 warnings/errors
- format: 0/289 files changed
- vulnerability audit: no vulnerable packages
- independent review and re-review: PASS/PASS, no findings

## Boundaries
- service login only; existing human/customer IAM flows remain unchanged
- missing keys fail at request time as bounded 503, not startup failure
- no legacy, wildcard, recursive, retry, or fallback handler on the dedicated client
- no GitOps, ArgoCD, Kubernetes, or deployment activation changes

Tracks MALIEV-Co-Ltd/maliev-ops#76