### PR TITLE
fix(auth): map IAM token issuance response contract

### DIFF
--- a/Maliev.AuthService.Infrastructure/HttpClients/TokenIssuancePermissionClient.cs
+++ b/Maliev.AuthService.Infrastructure/HttpClients/TokenIssuancePermissionClient.cs
@@ -22,19 +22,23 @@ public sealed class TokenIssuancePermissionClient : ITokenIssuancePermissionClie
     private readonly HttpClient _httpClient;
     private readonly ITokenIssuanceCapabilitySigner _signer;
     private readonly ILogger<TokenIssuancePermissionClient> _logger;
+    private readonly TimeProvider _timeProvider;
 
     /// <summary>Initializes the isolated IAM client.</summary>
     /// <param name="httpClient">The dedicated HTTP transport.</param>
     /// <param name="signer">The Auth-only capability signer.</param>
     /// <param name="logger">The client logger.</param>
+    /// <param name="timeProvider">The clock used to record when Auth observed the IAM response.</param>
     public TokenIssuancePermissionClient(
         HttpClient httpClient,
         ITokenIssuanceCapabilitySigner signer,
-        ILogger<TokenIssuancePermissionClient> logger)
+        ILogger<TokenIssuancePermissionClient> logger,
+        TimeProvider timeProvider)
     {
         _httpClient = httpClient;
         _signer = signer;
         _logger = logger;
+        _timeProvider = timeProvider;
     }
 
     /// <inheritdoc/>
@@ -64,10 +68,10 @@ public sealed class TokenIssuancePermissionClient : ITokenIssuancePermissionClie
             response.EnsureSuccessStatusCode();
         }
 
-        PermissionResolutionResponse? result;
+        TokenIssuancePermissionResponse? result;
         try
         {
-            result = await response.Content.ReadFromJsonAsync<PermissionResolutionResponse>(
+            result = await response.Content.ReadFromJsonAsync<TokenIssuancePermissionResponse>(
                 JsonOptions,
                 cancellationToken);
         }
@@ -90,12 +94,35 @@ public sealed class TokenIssuancePermissionClient : ITokenIssuancePermissionClie
             result.Roles is null ||
             result.Permissions.Any(value => string.IsNullOrWhiteSpace(value)) ||
             result.Roles.Any(value => string.IsNullOrWhiteSpace(value)) ||
-            result.ResolvedAt == default ||
-            result.CacheUntil < result.ResolvedAt)
+            result.FromCache ||
+            !string.IsNullOrEmpty(result.ResourcePath) ||
+            result.CacheUntil is not null)
         {
             throw new HttpRequestException(InvalidResponseMessage);
         }
 
-        return result;
+        return new PermissionResolutionResponse
+        {
+            PrincipalId = result.PrincipalId,
+            Permissions = result.Permissions,
+            Roles = result.Roles,
+            ResolvedAt = _timeProvider.GetUtcNow().UtcDateTime,
+            CacheUntil = null
+        };
+    }
+
+    private sealed record TokenIssuancePermissionResponse
+    {
+        public required Guid PrincipalId { get; init; }
+
+        public required List<string> Permissions { get; init; }
+
+        public required List<string> Roles { get; init; }
+
+        public string? ResourcePath { get; init; }
+
+        public DateTime? CacheUntil { get; init; }
+
+        public required bool FromCache { get; init; }
     }
 }

--- a/Maliev.AuthService.Infrastructure/HttpClients/TokenIssuancePermissionClient.cs
+++ b/Maliev.AuthService.Infrastructure/HttpClients/TokenIssuancePermissionClient.cs
@@ -95,7 +95,7 @@ public sealed class TokenIssuancePermissionClient : ITokenIssuancePermissionClie
             result.Permissions.Any(value => string.IsNullOrWhiteSpace(value)) ||
             result.Roles.Any(value => string.IsNullOrWhiteSpace(value)) ||
             result.FromCache ||
-            !string.IsNullOrEmpty(result.ResourcePath) ||
+            result.ResourcePath is not null ||
             result.CacheUntil is not null)
         {
             throw new HttpRequestException(InvalidResponseMessage);

--- a/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
@@ -470,6 +470,7 @@ public class ServiceLoginContractTests : IntegrationTestBase
     [InlineData("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "scoped-authority")]
     [InlineData("cccccccc-cccc-cccc-cccc-cccccccccccc", "expiring-authority")]
     [InlineData("dddddddd-dddd-dddd-dddd-dddddddddddd", "malformed-json")]
+    [InlineData("ffffffff-ffff-ffff-ffff-ffffffffffff", "empty-resource-path")]
     public async Task POST_V1_Auth_Service_Login_MalformedIamAuthority_ReturnsSanitized503WithoutToken(
         string principalId,
         string clientSuffix)

--- a/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ServiceLoginContractTests.cs
@@ -463,6 +463,13 @@ public class ServiceLoginContractTests : IntegrationTestBase
     [InlineData("44444444-4444-4444-4444-444444444444", "null-roles")]
     [InlineData("55555555-5555-5555-5555-555555555555", "null-permission-element")]
     [InlineData("66666666-6666-6666-6666-666666666666", "null-role-element")]
+    [InlineData("77777777-7777-7777-7777-777777777777", "blank-permission-element")]
+    [InlineData("88888888-8888-8888-8888-888888888888", "blank-role-element")]
+    [InlineData("99999999-9999-9999-9999-999999999999", "mismatched-principal")]
+    [InlineData("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "cached-authority")]
+    [InlineData("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "scoped-authority")]
+    [InlineData("cccccccc-cccc-cccc-cccc-cccccccccccc", "expiring-authority")]
+    [InlineData("dddddddd-dddd-dddd-dddd-dddddddddddd", "malformed-json")]
     public async Task POST_V1_Auth_Service_Login_MalformedIamAuthority_ReturnsSanitized503WithoutToken(
         string principalId,
         string clientSuffix)

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -33,6 +33,20 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         Guid.Parse("55555555-5555-5555-5555-555555555555");
     public static readonly Guid NullRoleElementIamPrincipalId =
         Guid.Parse("66666666-6666-6666-6666-666666666666");
+    public static readonly Guid BlankPermissionElementIamPrincipalId =
+        Guid.Parse("77777777-7777-7777-7777-777777777777");
+    public static readonly Guid BlankRoleElementIamPrincipalId =
+        Guid.Parse("88888888-8888-8888-8888-888888888888");
+    public static readonly Guid MismatchedIamPrincipalId =
+        Guid.Parse("99999999-9999-9999-9999-999999999999");
+    public static readonly Guid CachedIamPrincipalId =
+        Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    public static readonly Guid ScopedIamPrincipalId =
+        Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    public static readonly Guid ExpiringIamPrincipalId =
+        Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    public static readonly Guid MalformedJsonIamPrincipalId =
+        Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
     public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
@@ -362,13 +376,27 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                 var malformedAuthorityJson = principalId switch
                 {
                     var value when string.Equals(value, NullPermissionsIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
-                        $$"""{"principalId":"{{principalId}}","permissions":null,"roles":[],"resolvedAt":"2026-07-16T04:00:00Z"}""",
+                        $$"""{"principalId":"{{principalId}}","permissions":null,"roles":[],"resourcePath":null,"cacheUntil":null,"fromCache":false}""",
                     var value when string.Equals(value, NullRolesIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
-                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":null,"resolvedAt":"2026-07-16T04:00:00Z"}""",
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":null,"resourcePath":null,"cacheUntil":null,"fromCache":false}""",
                     var value when string.Equals(value, NullPermissionElementIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
-                        $$"""{"principalId":"{{principalId}}","permissions":[null],"roles":[],"resolvedAt":"2026-07-16T04:00:00Z"}""",
+                        $$"""{"principalId":"{{principalId}}","permissions":[null],"roles":[],"resourcePath":null,"cacheUntil":null,"fromCache":false}""",
                     var value when string.Equals(value, NullRoleElementIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
-                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[null],"resolvedAt":"2026-07-16T04:00:00Z"}""",
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[null],"resourcePath":null,"cacheUntil":null,"fromCache":false}""",
+                    var value when string.Equals(value, BlankPermissionElementIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":["   "],"roles":[],"resourcePath":null,"cacheUntil":null,"fromCache":false}""",
+                    var value when string.Equals(value, BlankRoleElementIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[""],"resourcePath":null,"cacheUntil":null,"fromCache":false}""",
+                    var value when string.Equals(value, MismatchedIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        """{"principalId":"eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee","permissions":[],"roles":[],"resourcePath":null,"cacheUntil":null,"fromCache":false}""",
+                    var value when string.Equals(value, CachedIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[],"resourcePath":null,"cacheUntil":null,"fromCache":true}""",
+                    var value when string.Equals(value, ScopedIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[],"resourcePath":"projects/project-1","cacheUntil":null,"fromCache":false}""",
+                    var value when string.Equals(value, ExpiringIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[],"resourcePath":null,"cacheUntil":"2026-07-16T04:05:00Z","fromCache":false}""",
+                    var value when string.Equals(value, MalformedJsonIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        "{not-json",
                     _ => null
                 };
                 if (malformedAuthorityJson is not null)
@@ -379,17 +407,19 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                     };
                 }
 
-                var response = new
-                {
-                    principalId = principalId ?? Guid.NewGuid().ToString(),
-                    permissions = new[] { "auth.api_keys.manage", "auth.users.read" },
-                    roles = new[] { "security_admin" },
-                    resolvedAt = DateTime.UtcNow
-                };
-
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = JsonContent.Create(response)
+                    Content = new StringContent(
+                        $$"""
+                        {
+                          "principalId": "{{principalId ?? Guid.NewGuid().ToString()}}",
+                          "permissions": ["auth.api_keys.manage", "auth.users.read"],
+                          "roles": ["security_admin"],
+                          "resourcePath": null,
+                          "cacheUntil": null,
+                          "fromCache": false
+                        }
+                        """)
                 };
             }
 

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -47,6 +47,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
     public static readonly Guid MalformedJsonIamPrincipalId =
         Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    public static readonly Guid EmptyResourcePathIamPrincipalId =
+        Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
     public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
@@ -397,6 +399,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                         $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[],"resourcePath":null,"cacheUntil":"2026-07-16T04:05:00Z","fromCache":false}""",
                     var value when string.Equals(value, MalformedJsonIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
                         "{not-json",
+                    var value when string.Equals(value, EmptyResourcePathIamPrincipalId.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                        $$"""{"principalId":"{{principalId}}","permissions":[],"roles":[],"resourcePath":"","cacheUntil":null,"fromCache":false}""",
                     _ => null
                 };
                 if (malformedAuthorityJson is not null)

--- a/Maliev.AuthService.Tests/Unit/TokenIssuancePermissionClientTests.cs
+++ b/Maliev.AuthService.Tests/Unit/TokenIssuancePermissionClientTests.cs
@@ -151,6 +151,7 @@ public sealed class TokenIssuancePermissionClientTests
     [Theory]
     [InlineData("true", "null", "null")]
     [InlineData("false", "\"projects/project-1\"", "null")]
+    [InlineData("false", "\"\"", "null")]
     [InlineData("false", "null", "\"2026-07-16T04:05:00Z\"")]
     public async Task ResolvePermissionsAsync_NonAuthoritativeTokenIssuanceMetadata_ThrowsControlledClientFailure(
         string fromCache,

--- a/Maliev.AuthService.Tests/Unit/TokenIssuancePermissionClientTests.cs
+++ b/Maliev.AuthService.Tests/Unit/TokenIssuancePermissionClientTests.cs
@@ -11,6 +11,8 @@ namespace Maliev.AuthService.Tests.Unit;
 public sealed class TokenIssuancePermissionClientTests
 {
     private static readonly Guid PrincipalId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly DateTimeOffset ObservedAt =
+        new(2026, 7, 16, 4, 0, 0, TimeSpan.Zero);
 
     [Fact]
     public async Task ResolvePermissionsAsync_ValidResponse_UsesOnlyAdditiveRouteAndTargetCoupledToken()
@@ -26,21 +28,28 @@ public sealed class TokenIssuancePermissionClientTests
             Assert.Equal(PrincipalId.ToString("D"), json.RootElement.GetProperty("principalId").GetString());
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = JsonContent.Create(new
-                {
-                    principalId = PrincipalId,
-                    permissions = new[] { "customer.customers.read" },
-                    roles = new[] { "service.customer" },
-                    resolvedAt = DateTime.UtcNow,
-                    cacheUntil = (DateTime?)null
-                })
+                Content = new StringContent(
+                    $$"""
+                    {
+                      "principalId": "{{PrincipalId:D}}",
+                      "permissions": ["customer.customers.read"],
+                      "roles": ["service.customer"],
+                      "resourcePath": null,
+                      "cacheUntil": null,
+                      "fromCache": false
+                    }
+                    """)
             };
         }))
         {
             BaseAddress = new Uri("https://iam.test"),
             Timeout = TimeSpan.FromSeconds(10)
         };
-        var client = new TokenIssuancePermissionClient(httpClient, signer, NullLogger<TokenIssuancePermissionClient>.Instance);
+        var client = new TokenIssuancePermissionClient(
+            httpClient,
+            signer,
+            NullLogger<TokenIssuancePermissionClient>.Instance,
+            new FixedTimeProvider(ObservedAt));
 
         var response = await client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None);
 
@@ -53,6 +62,8 @@ public sealed class TokenIssuancePermissionClientTests
         Assert.Equal(PrincipalId, response.PrincipalId);
         Assert.Equal(["customer.customers.read"], response.Permissions);
         Assert.Equal(["service.customer"], response.Roles);
+        Assert.Equal(ObservedAt.UtcDateTime, response.ResolvedAt);
+        Assert.Null(response.CacheUntil);
     }
 
     [Theory]
@@ -86,13 +97,17 @@ public sealed class TokenIssuancePermissionClientTests
     {
         var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = JsonContent.Create(new
-            {
-                principalId = Guid.NewGuid(),
-                permissions = Array.Empty<string>(),
-                roles = Array.Empty<string>(),
-                resolvedAt = DateTime.UtcNow
-            })
+            Content = new StringContent(
+                $$"""
+                {
+                  "principalId": "{{Guid.NewGuid():D}}",
+                  "permissions": [],
+                  "roles": [],
+                  "resourcePath": null,
+                  "cacheUntil": null,
+                  "fromCache": false
+                }
+                """)
         }));
 
         await Assert.ThrowsAsync<HttpRequestException>(() =>
@@ -120,7 +135,9 @@ public sealed class TokenIssuancePermissionClientTests
                   "principalId": "{{PrincipalId:D}}",
                   "permissions": {{permissions}},
                   "roles": {{roles}},
-                  "resolvedAt": "2026-07-16T04:00:00Z"
+                  "resourcePath": null,
+                  "cacheUntil": null,
+                  "fromCache": false
                 }
                 """)
         }));
@@ -131,38 +148,28 @@ public sealed class TokenIssuancePermissionClientTests
         Assert.Equal("IAM token-issuance permission resolution returned an invalid response.", exception.Message);
     }
 
-    [Fact]
-    public async Task ResolvePermissionsAsync_MissingResolvedTimestamp_ThrowsControlledClientFailure()
+    [Theory]
+    [InlineData("true", "null", "null")]
+    [InlineData("false", "\"projects/project-1\"", "null")]
+    [InlineData("false", "null", "\"2026-07-16T04:05:00Z\"")]
+    public async Task ResolvePermissionsAsync_NonAuthoritativeTokenIssuanceMetadata_ThrowsControlledClientFailure(
+        string fromCache,
+        string resourcePath,
+        string cacheUntil)
     {
         var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = JsonContent.Create(new
-            {
-                principalId = PrincipalId,
-                permissions = Array.Empty<string>(),
-                roles = Array.Empty<string>()
-            })
-        }));
-
-        var exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
-
-        Assert.Equal("IAM token-issuance permission resolution returned an invalid response.", exception.Message);
-    }
-
-    [Fact]
-    public async Task ResolvePermissionsAsync_CacheExpiryBeforeResolution_ThrowsControlledClientFailure()
-    {
-        var client = CreateClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = JsonContent.Create(new
-            {
-                principalId = PrincipalId,
-                permissions = Array.Empty<string>(),
-                roles = Array.Empty<string>(),
-                resolvedAt = new DateTime(2026, 7, 16, 4, 0, 0, DateTimeKind.Utc),
-                cacheUntil = new DateTime(2026, 7, 16, 3, 59, 59, DateTimeKind.Utc)
-            })
+            Content = new StringContent(
+                $$"""
+                {
+                  "principalId": "{{PrincipalId:D}}",
+                  "permissions": [],
+                  "roles": [],
+                  "resourcePath": {{resourcePath}},
+                  "cacheUntil": {{cacheUntil}},
+                  "fromCache": {{fromCache}}
+                }
+                """)
         }));
 
         var exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
@@ -198,7 +205,8 @@ public sealed class TokenIssuancePermissionClientTests
         var client = new TokenIssuancePermissionClient(
             httpClient,
             new RecordingSigner(),
-            NullLogger<TokenIssuancePermissionClient>.Instance);
+            NullLogger<TokenIssuancePermissionClient>.Instance,
+            TimeProvider.System);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
             client.ResolvePermissionsAsync(PrincipalId, CancellationToken.None));
@@ -215,7 +223,8 @@ public sealed class TokenIssuancePermissionClientTests
         return new TokenIssuancePermissionClient(
             httpClient,
             new RecordingSigner(),
-            NullLogger<TokenIssuancePermissionClient>.Instance);
+            NullLogger<TokenIssuancePermissionClient>.Instance,
+            TimeProvider.System);
     }
 
     private sealed class RecordingSigner : ITokenIssuanceCapabilitySigner
@@ -227,6 +236,11 @@ public sealed class TokenIssuancePermissionClientTests
             TargetPrincipalId = targetPrincipalId;
             return "capability-token";
         }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
     }
 
     private sealed class DelegatingTestHandler(


### PR DESCRIPTION
## Summary
- deserialize IAM's existing six-field v1 response through a dedicated wire DTO
- enforce authoritative token-issuance invariants: requested principal, valid authority entries, no cache, no resource scope
- map validated wire data explicitly to Auth's internal response with a local observation timestamp
- preserve IAM v1, the legacy IAM client, and the dedicated capability route

## Validation
- controller focused rerun: 46/46 passed
- focused contract boundary: 30/30 passed
- full Release suite: 414/414 passed
- Release build: 0 warnings/errors
- format: 0/289 files changed
- vulnerability audit and diff checks clean
- independent review/re-review: PASS/PASS, no findings

## Boundaries
- no IAM route or response changes
- no legacy authentication flow changes
- no GitOps, ArgoCD, Kubernetes, or deployment activation changes

Unblocks the retained real hosted Auth-to-IAM test in MALIEV-Co-Ltd/maliev-ops#76.