### PR TITLE
test(auth): isolate SearchService credentials

### DIFF
--- a/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
@@ -1,3 +1,4 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
@@ -68,15 +69,17 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
     }
 
     [Fact]
-    public async Task ServiceLogin_AuthAndContactCredentials_CannotBeCrossed()
+    public async Task ServiceLogin_AuthContactAndSearchCredentials_AreIsolatedAndSearchClaimsAreCanonical()
     {
         const string authSecret = "auth-service-secret-with-at-least-32-random-looking-bytes";
         const string contactSecret = "contact-service-secret-with-at-least-32-random-looking-bytes";
+        const string searchSecret = "search-service-secret-with-at-least-32-random-looking-bytes";
         await SeedManagedCredentialAsync(
             "service-auth-service",
             "auth-service",
             "roles.workloads.auth-service.v1",
             Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            "AuthService",
             true,
             (authSecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
         await SeedManagedCredentialAsync(
@@ -84,27 +87,79 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "contact-service",
             "roles.workloads.contact-service.v1",
             Guid.Parse("12121212-1212-1212-1212-121212121212"),
+            "ContactService",
             true,
             (contactSecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
+        await SeedManagedCredentialAsync(
+            "service-search-service",
+            "search-service",
+            "roles.workloads.search-service.v1",
+            TestWebApplicationFactory.SearchServiceIamPrincipalId,
+            "SearchService",
+            true,
+            (searchSecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
         using var client = factory.CreateClient();
 
         var auth = await LoginAsync(client, "service-auth-service", authSecret, "127.0.13.1");
         var contact = await LoginAsync(client, "service-contact-service", contactSecret, "127.0.13.2");
+        var search = await LoginAsync(client, "service-search-service", searchSecret, "127.0.13.3");
         var authClientWithContactSecret = await LoginAsync(
             client,
             "service-auth-service",
             contactSecret,
-            "127.0.13.3");
+            "127.0.13.4");
+        var authClientWithSearchSecret = await LoginAsync(
+            client,
+            "service-auth-service",
+            searchSecret,
+            "127.0.13.5");
         var contactClientWithAuthSecret = await LoginAsync(
             client,
             "service-contact-service",
             authSecret,
-            "127.0.13.4");
+            "127.0.13.6");
+        var contactClientWithSearchSecret = await LoginAsync(
+            client,
+            "service-contact-service",
+            searchSecret,
+            "127.0.13.7");
+        var searchClientWithAuthSecret = await LoginAsync(
+            client,
+            "service-search-service",
+            authSecret,
+            "127.0.13.8");
+        var searchClientWithContactSecret = await LoginAsync(
+            client,
+            "service-search-service",
+            contactSecret,
+            "127.0.13.9");
 
         Assert.Equal(HttpStatusCode.OK, auth.StatusCode);
         Assert.Equal(HttpStatusCode.OK, contact.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, search.StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, authClientWithContactSecret.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, authClientWithSearchSecret.StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, contactClientWithAuthSecret.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, contactClientWithSearchSecret.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, searchClientWithAuthSecret.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, searchClientWithContactSecret.StatusCode);
+
+        var searchResponse = JsonDocument.Parse(await search.Content.ReadAsStringAsync());
+        var searchToken = new JwtSecurityTokenHandler().ReadJwtToken(
+            searchResponse.RootElement.GetProperty("access_token").GetString());
+        Assert.Equal(TestWebApplicationFactory.SearchServiceIamPrincipalId.ToString(), searchToken.Subject);
+        Assert.Equal(
+            "service-search-service",
+            searchToken.Claims.Single(claim => claim.Type == "client_id").Value);
+        Assert.Equal(
+            "SearchService",
+            searchToken.Claims.Single(claim => claim.Type == "service_name").Value);
+        Assert.Equal(
+            ["iam.auth.check-permission"],
+            searchToken.Claims.Where(claim => claim.Type == "permissions").Select(claim => claim.Value));
+        Assert.Equal(
+            ["roles.workloads.search-service.v1"],
+            searchToken.Claims.Where(claim => claim.Type == "roles").Select(claim => claim.Value));
     }
 
     private static async Task<HttpResponseMessage> LoginAsync(
@@ -144,6 +199,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "auth-service",
             "roles.workloads.auth-service.v1",
             Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            "AuthService",
             logicalActive,
             versions);
 
@@ -152,6 +208,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         string workloadId,
         string roleId,
         Guid principalId,
+        string serviceName,
         bool logicalActive,
         params (string Secret, ServiceCredentialVersionStatus Status, DateTimeOffset HardExpiry, DateTimeOffset? GraceExpiry)[] versions)
     {
@@ -166,7 +223,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             ProfileVersion = 1,
             RoleId = roleId,
             ClientSecretHash = Hash(versions[0].Secret),
-            ServiceName = workloadId,
+            ServiceName = serviceName,
             IsActive = logicalActive,
             RevokedAt = logicalActive ? null : DateTimeOffset.UtcNow,
             CreatedAt = now.UtcDateTime,

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -49,6 +49,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
     public static readonly Guid EmptyResourcePathIamPrincipalId =
         Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    public static readonly Guid SearchServiceIamPrincipalId =
+        Guid.Parse("13131313-1313-1313-1313-131313131313");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
     public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
@@ -408,6 +410,27 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
                         Content = new StringContent(malformedAuthorityJson)
+                    };
+                }
+
+                if (string.Equals(
+                    principalId,
+                    SearchServiceIamPrincipalId.ToString(),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            $$"""
+                            {
+                              "principalId": "{{principalId}}",
+                              "permissions": ["iam.auth.check-permission"],
+                              "roles": ["roles.workloads.search-service.v1"],
+                              "resourcePath": null,
+                              "cacheUntil": null,
+                              "fromCache": false
+                            }
+                            """)
                     };
                 }
 


### PR DESCRIPTION
## Summary\n- add SearchService as a distinct managed service-credential test identity\n- prove correct AuthService, ContactService, and SearchService credentials issue tokens while every crossed pair is rejected\n- assert Search tokens preserve the canonical service identity and exact IAM-resolved Search role/permission set\n\n## Security boundary\nAuthService does not define or grant Search authority. The test IAM boundary returns the already-defined Search workload profile for its principal, and AuthService only forwards that authoritative response into the token. Existing service credentials and endpoint contracts remain unchanged.\n\n## Validation\n- RED: Search claim assertion received generic Auth test authority instead of iam.auth.check-permission\n- focused new regression: 1/1\n- managed credential contracts: 6/6\n- full Release tests: 415/415\n- Release build: 0 warnings, 0 errors\n- dotnet format --verify-no-changes: passed\n- pre-commit hooks on both changed files: passed\n\nTracks MALIEV-Co-Ltd/maliev-ops#81\n\nNo deployment or GitOps change.