### PR TITLE
test(auth): prove CountryService credential isolation

### DIFF
--- a/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
@@ -17,6 +17,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
     private const string ContactSecret = "contact-service-secret-with-at-least-32-random-looking-bytes";
     private const string SearchSecret = "search-service-secret-with-at-least-32-random-looking-bytes";
     private const string RegistrySecret = "registry-service-secret-with-at-least-32-random-looking-bytes";
+    private const string CountrySecret = "country-service-secret-with-at-least-32-random-looking-bytes";
 
     public Task InitializeAsync() => factory.CleanDatabaseAsync();
 
@@ -83,11 +84,13 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         var contact = await LoginAsync(client, "service-contact-service", ContactSecret, "127.0.13.2");
         var search = await LoginAsync(client, "service-search-service", SearchSecret, "127.0.13.3");
         var registry = await LoginAsync(client, "service-registry-service", RegistrySecret, "127.0.13.4");
+        var country = await LoginAsync(client, "service-country-service", CountrySecret, "127.0.13.5");
 
         Assert.Equal(HttpStatusCode.OK, auth.StatusCode);
         Assert.Equal(HttpStatusCode.OK, contact.StatusCode);
         Assert.Equal(HttpStatusCode.OK, search.StatusCode);
         Assert.Equal(HttpStatusCode.OK, registry.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, country.StatusCode);
 
         await AssertCanonicalServiceTokenAsync(
             search,
@@ -101,29 +104,38 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "service-registry-service",
             "RegistryService",
             "roles.workloads.registry-service.v1");
+        await AssertCanonicalServiceTokenAsync(
+            country,
+            TestWebApplicationFactory.CountryServiceIamPrincipalId,
+            "service-country-service",
+            "CountryService",
+            "roles.workloads.country-service.v1");
     }
 
     [Theory]
-    [InlineData("service-auth-service", ContactSecret, SearchSecret, RegistrySecret)]
-    [InlineData("service-contact-service", AuthSecret, SearchSecret, RegistrySecret)]
-    [InlineData("service-search-service", AuthSecret, ContactSecret, RegistrySecret)]
-    [InlineData("service-registry-service", AuthSecret, ContactSecret, SearchSecret)]
+    [InlineData("service-auth-service", ContactSecret, SearchSecret)]
+    [InlineData("service-auth-service", RegistrySecret, CountrySecret)]
+    [InlineData("service-contact-service", AuthSecret, SearchSecret)]
+    [InlineData("service-contact-service", RegistrySecret, CountrySecret)]
+    [InlineData("service-search-service", AuthSecret, ContactSecret)]
+    [InlineData("service-search-service", RegistrySecret, CountrySecret)]
+    [InlineData("service-registry-service", AuthSecret, ContactSecret)]
+    [InlineData("service-registry-service", SearchSecret, CountrySecret)]
+    [InlineData("service-country-service", AuthSecret, ContactSecret)]
+    [InlineData("service-country-service", SearchSecret, RegistrySecret)]
     public async Task ServiceLogin_CrossedManagedServiceCredentials_AreUnauthorized(
         string clientId,
         string firstWrongSecret,
-        string secondWrongSecret,
-        string thirdWrongSecret)
+        string secondWrongSecret)
     {
         await SeedCanonicalManagedCredentialsAsync();
         using var client = factory.CreateClient();
 
         var first = await LoginAsync(client, clientId, firstWrongSecret, "127.0.14.1");
         var second = await LoginAsync(client, clientId, secondWrongSecret, "127.0.14.2");
-        var third = await LoginAsync(client, clientId, thirdWrongSecret, "127.0.14.3");
 
         Assert.Equal(HttpStatusCode.Unauthorized, first.StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, second.StatusCode);
-        Assert.Equal(HttpStatusCode.Unauthorized, third.StatusCode);
     }
 
     private async Task SeedCanonicalManagedCredentialsAsync()
@@ -160,6 +172,14 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "RegistryService",
             true,
             (RegistrySecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
+        await SeedManagedCredentialAsync(
+            "service-country-service",
+            "country-service",
+            "roles.workloads.country-service.v1",
+            TestWebApplicationFactory.CountryServiceIamPrincipalId,
+            "CountryService",
+            true,
+            (CountrySecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
     }
 
     private static async Task AssertCanonicalServiceTokenAsync(

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -53,6 +53,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         Guid.Parse("13131313-1313-1313-1313-131313131313");
     public static readonly Guid RegistryServiceIamPrincipalId =
         Guid.Parse("14141414-1414-1414-1414-141414141414");
+    public static readonly Guid CountryServiceIamPrincipalId =
+        Guid.Parse("15151515-1515-1515-1515-151515151515");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
     public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
@@ -449,6 +451,27 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                               "principalId": "{{principalId}}",
                               "permissions": ["iam.auth.check-permission"],
                               "roles": ["roles.workloads.registry-service.v1"],
+                              "resourcePath": null,
+                              "cacheUntil": null,
+                              "fromCache": false
+                            }
+                            """)
+                    };
+                }
+
+                if (string.Equals(
+                    principalId,
+                    CountryServiceIamPrincipalId.ToString(),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            $$"""
+                            {
+                              "principalId": "{{principalId}}",
+                              "permissions": ["iam.auth.check-permission"],
+                              "roles": ["roles.workloads.country-service.v1"],
                               "resourcePath": null,
                               "cacheUntil": null,
                               "fromCache": false


### PR DESCRIPTION
## Summary
- seed the canonical CountryService managed credential in the real PostgreSQL Auth contract fixture
- assert the issued JWT has the Country principal/client/service identity, exactly `iam.auth.check-permission`, and exactly `roles.workloads.country-service.v1`
- expand crossed-secret isolation to every ordered pair across Auth, Contact, Search, Registry, and Country
- partition crossed attempts into two per theory case so the existing 3/client and 3/peer limits remain unchanged

## Scope
Test-only credential proof for MALIEV ops issue #91. No production credentials, configuration, runtime code, merge, deployment, or GitOps activation.

## TDD evidence
- RED: Country login reached the real controller and issued a token, but exact authority assertion rejected fallback claims `auth.api_keys.manage` and `auth.users.read`
- GREEN focused: `ManagedServiceLoginContractTests` 16/16

## Validation
- `dotnet test Maliev.AuthService.slnx --configuration Release --verbosity minimal --no-restore` — 425/425
- `dotnet build Maliev.AuthService.slnx --configuration Release --no-restore` — 0 warnings, 0 errors
- `dotnet format Maliev.AuthService.slnx --verify-no-changes --no-restore --verbosity minimal` — passed
- `pre-commit run --files Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs` — passed

Tracking: MALIEV-Co-Ltd/maliev-ops#91