### PR TITLE
test(auth): prove CurrencyService credential isolation

### DIFF
--- a/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
@@ -18,6 +18,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
     private const string SearchSecret = "search-service-secret-with-at-least-32-random-looking-bytes";
     private const string RegistrySecret = "registry-service-secret-with-at-least-32-random-looking-bytes";
     private const string CountrySecret = "country-service-secret-with-at-least-32-random-looking-bytes";
+    private const string CurrencySecret = "currency-service-secret-with-at-least-32-random-looking-bytes";
 
     public Task InitializeAsync() => factory.CleanDatabaseAsync();
 
@@ -85,12 +86,14 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         var search = await LoginAsync(client, "service-search-service", SearchSecret, "127.0.13.3");
         var registry = await LoginAsync(client, "service-registry-service", RegistrySecret, "127.0.13.4");
         var country = await LoginAsync(client, "service-country-service", CountrySecret, "127.0.13.5");
+        var currency = await LoginAsync(client, "service-currency-service", CurrencySecret, "127.0.13.6");
 
         Assert.Equal(HttpStatusCode.OK, auth.StatusCode);
         Assert.Equal(HttpStatusCode.OK, contact.StatusCode);
         Assert.Equal(HttpStatusCode.OK, search.StatusCode);
         Assert.Equal(HttpStatusCode.OK, registry.StatusCode);
         Assert.Equal(HttpStatusCode.OK, country.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, currency.StatusCode);
 
         await AssertCanonicalServiceTokenAsync(
             search,
@@ -110,32 +113,48 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "service-country-service",
             "CountryService",
             "roles.workloads.country-service.v1");
+        await AssertCanonicalServiceTokenAsync(
+            currency,
+            TestWebApplicationFactory.CurrencyServiceIamPrincipalId,
+            "service-currency-service",
+            "CurrencyService",
+            "roles.workloads.currency-service.v1");
     }
 
     [Theory]
-    [InlineData("service-auth-service", ContactSecret, SearchSecret)]
-    [InlineData("service-auth-service", RegistrySecret, CountrySecret)]
-    [InlineData("service-contact-service", AuthSecret, SearchSecret)]
-    [InlineData("service-contact-service", RegistrySecret, CountrySecret)]
-    [InlineData("service-search-service", AuthSecret, ContactSecret)]
-    [InlineData("service-search-service", RegistrySecret, CountrySecret)]
-    [InlineData("service-registry-service", AuthSecret, ContactSecret)]
-    [InlineData("service-registry-service", SearchSecret, CountrySecret)]
-    [InlineData("service-country-service", AuthSecret, ContactSecret)]
-    [InlineData("service-country-service", SearchSecret, RegistrySecret)]
+    [InlineData("service-auth-service", ContactSecret, SearchSecret, RegistrySecret)]
+    [InlineData("service-auth-service", CountrySecret, CurrencySecret, null)]
+    [InlineData("service-contact-service", AuthSecret, SearchSecret, RegistrySecret)]
+    [InlineData("service-contact-service", CountrySecret, CurrencySecret, null)]
+    [InlineData("service-search-service", AuthSecret, ContactSecret, RegistrySecret)]
+    [InlineData("service-search-service", CountrySecret, CurrencySecret, null)]
+    [InlineData("service-registry-service", AuthSecret, ContactSecret, SearchSecret)]
+    [InlineData("service-registry-service", CountrySecret, CurrencySecret, null)]
+    [InlineData("service-country-service", AuthSecret, ContactSecret, SearchSecret)]
+    [InlineData("service-country-service", RegistrySecret, CurrencySecret, null)]
+    [InlineData("service-currency-service", AuthSecret, ContactSecret, SearchSecret)]
+    [InlineData("service-currency-service", RegistrySecret, CountrySecret, null)]
     public async Task ServiceLogin_CrossedManagedServiceCredentials_AreUnauthorized(
         string clientId,
         string firstWrongSecret,
-        string secondWrongSecret)
+        string secondWrongSecret,
+        string? thirdWrongSecret)
     {
         await SeedCanonicalManagedCredentialsAsync();
         using var client = factory.CreateClient();
 
         var first = await LoginAsync(client, clientId, firstWrongSecret, "127.0.14.1");
         var second = await LoginAsync(client, clientId, secondWrongSecret, "127.0.14.2");
+        var third = thirdWrongSecret is null
+            ? null
+            : await LoginAsync(client, clientId, thirdWrongSecret, "127.0.14.3");
 
         Assert.Equal(HttpStatusCode.Unauthorized, first.StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, second.StatusCode);
+        if (third is not null)
+        {
+            Assert.Equal(HttpStatusCode.Unauthorized, third.StatusCode);
+        }
     }
 
     private async Task SeedCanonicalManagedCredentialsAsync()
@@ -180,6 +199,14 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "CountryService",
             true,
             (CountrySecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
+        await SeedManagedCredentialAsync(
+            "service-currency-service",
+            "currency-service",
+            "roles.workloads.currency-service.v1",
+            TestWebApplicationFactory.CurrencyServiceIamPrincipalId,
+            "CurrencyService",
+            true,
+            (CurrencySecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
     }
 
     private static async Task AssertCanonicalServiceTokenAsync(

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -55,6 +55,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         Guid.Parse("14141414-1414-1414-1414-141414141414");
     public static readonly Guid CountryServiceIamPrincipalId =
         Guid.Parse("15151515-1515-1515-1515-151515151515");
+    public static readonly Guid CurrencyServiceIamPrincipalId =
+        Guid.Parse("16161616-1616-1616-1616-161616161616");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
     public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
@@ -472,6 +474,27 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                               "principalId": "{{principalId}}",
                               "permissions": ["iam.auth.check-permission"],
                               "roles": ["roles.workloads.country-service.v1"],
+                              "resourcePath": null,
+                              "cacheUntil": null,
+                              "fromCache": false
+                            }
+                            """)
+                    };
+                }
+
+                if (string.Equals(
+                    principalId,
+                    CurrencyServiceIamPrincipalId.ToString(),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            $$"""
+                            {
+                              "principalId": "{{principalId}}",
+                              "permissions": ["iam.auth.check-permission"],
+                              "roles": ["roles.workloads.currency-service.v1"],
                               "resourcePath": null,
                               "cacheUntil": null,
                               "fromCache": false


### PR DESCRIPTION
## Summary
- seed the canonical CurrencyService managed credential in the real PostgreSQL Auth contract fixture
- assert its JWT has the Currency principal/client/service identity, exactly `iam.auth.check-permission`, and exactly `roles.workloads.currency-service.v1`
- expand crossed-secret isolation to all 30 ordered pairs across Auth, Contact, Search, Registry, Country, and Currency
- partition each target into a three-attempt and a two-attempt case so existing 3/client and 3/peer limits remain unchanged

## Scope
Test-only credential proof for MALIEV ops issue #92. Synthetic test credentials only; no production credential, configuration, runtime code, merge, deployment, or GitOps activation.

## TDD evidence
- RED: Currency login reached the real controller and issued a token, but exact authority assertion rejected fallback claims `auth.api_keys.manage` and `auth.users.read`
- GREEN focused: `ManagedServiceLoginContractTests` 18/18

## Validation
- `dotnet test Maliev.AuthService.slnx --configuration Release --verbosity minimal --no-restore` — 427/427
- `dotnet build Maliev.AuthService.slnx --configuration Release --no-restore` — 0 warnings, 0 errors
- `dotnet format Maliev.AuthService.slnx --verify-no-changes --no-restore --verbosity minimal` — passed
- `pre-commit run --files Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs` — passed

Tracking: MALIEV-Co-Ltd/maliev-ops#92