### PR TITLE
test(auth): prove AccountingService credential isolation

### DIFF
--- a/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
@@ -19,6 +19,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
     private const string RegistrySecret = "registry-service-secret-with-at-least-32-random-looking-bytes";
     private const string CountrySecret = "country-service-secret-with-at-least-32-random-looking-bytes";
     private const string CurrencySecret = "currency-service-secret-with-at-least-32-random-looking-bytes";
+    private const string AccountingSecret = "accounting-service-secret-with-at-least-32-random-looking-bytes";
 
     public Task InitializeAsync() => factory.CleanDatabaseAsync();
 
@@ -87,6 +88,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         var registry = await LoginAsync(client, "service-registry-service", RegistrySecret, "127.0.13.4");
         var country = await LoginAsync(client, "service-country-service", CountrySecret, "127.0.13.5");
         var currency = await LoginAsync(client, "service-currency-service", CurrencySecret, "127.0.13.6");
+        var accounting = await LoginAsync(client, "service-accounting-service", AccountingSecret, "127.0.13.7");
 
         Assert.Equal(HttpStatusCode.OK, auth.StatusCode);
         Assert.Equal(HttpStatusCode.OK, contact.StatusCode);
@@ -94,6 +96,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         Assert.Equal(HttpStatusCode.OK, registry.StatusCode);
         Assert.Equal(HttpStatusCode.OK, country.StatusCode);
         Assert.Equal(HttpStatusCode.OK, currency.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, accounting.StatusCode);
 
         await AssertCanonicalServiceTokenAsync(
             search,
@@ -119,42 +122,45 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "service-currency-service",
             "CurrencyService",
             "roles.workloads.currency-service.v1");
+        await AssertCanonicalServiceTokenAsync(
+            accounting,
+            TestWebApplicationFactory.AccountingServiceIamPrincipalId,
+            "service-accounting-service",
+            "AccountingService",
+            "roles.workloads.accounting-service.v1");
     }
 
     [Theory]
     [InlineData("service-auth-service", ContactSecret, SearchSecret, RegistrySecret)]
-    [InlineData("service-auth-service", CountrySecret, CurrencySecret, null)]
+    [InlineData("service-auth-service", CountrySecret, CurrencySecret, AccountingSecret)]
     [InlineData("service-contact-service", AuthSecret, SearchSecret, RegistrySecret)]
-    [InlineData("service-contact-service", CountrySecret, CurrencySecret, null)]
+    [InlineData("service-contact-service", CountrySecret, CurrencySecret, AccountingSecret)]
     [InlineData("service-search-service", AuthSecret, ContactSecret, RegistrySecret)]
-    [InlineData("service-search-service", CountrySecret, CurrencySecret, null)]
+    [InlineData("service-search-service", CountrySecret, CurrencySecret, AccountingSecret)]
     [InlineData("service-registry-service", AuthSecret, ContactSecret, SearchSecret)]
-    [InlineData("service-registry-service", CountrySecret, CurrencySecret, null)]
+    [InlineData("service-registry-service", CountrySecret, CurrencySecret, AccountingSecret)]
     [InlineData("service-country-service", AuthSecret, ContactSecret, SearchSecret)]
-    [InlineData("service-country-service", RegistrySecret, CurrencySecret, null)]
+    [InlineData("service-country-service", RegistrySecret, CurrencySecret, AccountingSecret)]
     [InlineData("service-currency-service", AuthSecret, ContactSecret, SearchSecret)]
-    [InlineData("service-currency-service", RegistrySecret, CountrySecret, null)]
+    [InlineData("service-currency-service", RegistrySecret, CountrySecret, AccountingSecret)]
+    [InlineData("service-accounting-service", AuthSecret, ContactSecret, SearchSecret)]
+    [InlineData("service-accounting-service", RegistrySecret, CountrySecret, CurrencySecret)]
     public async Task ServiceLogin_CrossedManagedServiceCredentials_AreUnauthorized(
         string clientId,
         string firstWrongSecret,
         string secondWrongSecret,
-        string? thirdWrongSecret)
+        string thirdWrongSecret)
     {
         await SeedCanonicalManagedCredentialsAsync();
         using var client = factory.CreateClient();
 
         var first = await LoginAsync(client, clientId, firstWrongSecret, "127.0.14.1");
         var second = await LoginAsync(client, clientId, secondWrongSecret, "127.0.14.2");
-        var third = thirdWrongSecret is null
-            ? null
-            : await LoginAsync(client, clientId, thirdWrongSecret, "127.0.14.3");
+        var third = await LoginAsync(client, clientId, thirdWrongSecret, "127.0.14.3");
 
         Assert.Equal(HttpStatusCode.Unauthorized, first.StatusCode);
         Assert.Equal(HttpStatusCode.Unauthorized, second.StatusCode);
-        if (third is not null)
-        {
-            Assert.Equal(HttpStatusCode.Unauthorized, third.StatusCode);
-        }
+        Assert.Equal(HttpStatusCode.Unauthorized, third.StatusCode);
     }
 
     private async Task SeedCanonicalManagedCredentialsAsync()
@@ -207,6 +213,14 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "CurrencyService",
             true,
             (CurrencySecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
+        await SeedManagedCredentialAsync(
+            "service-accounting-service",
+            "accounting-service",
+            "roles.workloads.accounting-service.v1",
+            TestWebApplicationFactory.AccountingServiceIamPrincipalId,
+            "AccountingService",
+            true,
+            (AccountingSecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
     }
 
     private static async Task AssertCanonicalServiceTokenAsync(

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -57,6 +57,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         Guid.Parse("15151515-1515-1515-1515-151515151515");
     public static readonly Guid CurrencyServiceIamPrincipalId =
         Guid.Parse("16161616-1616-1616-1616-161616161616");
+    public static readonly Guid AccountingServiceIamPrincipalId =
+        Guid.Parse("17171717-1717-1717-1717-171717171717");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
     public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
@@ -495,6 +497,27 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                               "principalId": "{{principalId}}",
                               "permissions": ["iam.auth.check-permission"],
                               "roles": ["roles.workloads.currency-service.v1"],
+                              "resourcePath": null,
+                              "cacheUntil": null,
+                              "fromCache": false
+                            }
+                            """)
+                    };
+                }
+
+                if (string.Equals(
+                    principalId,
+                    AccountingServiceIamPrincipalId.ToString(),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            $$"""
+                            {
+                              "principalId": "{{principalId}}",
+                              "permissions": ["iam.auth.check-permission"],
+                              "roles": ["roles.workloads.accounting-service.v1"],
                               "resourcePath": null,
                               "cacheUntil": null,
                               "fromCache": false


### PR DESCRIPTION
## Summary
- add the AccountingService managed credential to the canonical service-login contract
- assert the Accounting principal, client, workload service, role, and sole IAM permission without default-admin fallthrough
- cover all 42 ordered crossed-secret combinations as 14 isolated three-attempt rows while preserving the existing client and peer rate limits

## Validation
- RED: focused contract suite failed only because Accounting fell through to default admin claims
- GREEN: focused `ManagedServiceLoginContractTests` 20/20
- full Release test suite 429/429 with PostgreSQL, Redis, and RabbitMQ Testcontainers
- Release build: 0 warnings, 0 errors
- `dotnet format --verify-no-changes --no-restore`
- `git diff --check`

## Boundaries
- test-only change; no production configuration or runtime code
- no deployment or GitOps state change

Tracks MALIEV-Co-Ltd/maliev-ops#94 (Task 2).