### PR TITLE
test(auth): isolate LifecycleService workload credential

### DIFF
--- a/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
@@ -22,6 +22,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
     private const string AccountingSecret = "accounting-service-secret-with-at-least-32-random-looking-bytes";
     private const string PricingSecret = "pricing-service-secret-with-at-least-32-random-looking-bytes";
     private const string MaterialSecret = "material-service-secret-with-at-least-32-random-looking-bytes";
+    private const string LifecycleSecret = "lifecycle-service-secret-with-at-least-32-random-looking-bytes";
     private static readonly (string ClientId, string Secret)[] CanonicalManagedCredentials =
     [
         ("service-auth-service", AuthSecret),
@@ -32,7 +33,8 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         ("service-currency-service", CurrencySecret),
         ("service-accounting-service", AccountingSecret),
         ("service-pricing-service", PricingSecret),
-        ("service-material-service", MaterialSecret)
+        ("service-material-service", MaterialSecret),
+        ("service-lifecycle-service", LifecycleSecret)
     ];
 
     public Task InitializeAsync() => factory.CleanDatabaseAsync();
@@ -105,6 +107,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         var accounting = await LoginAsync(client, "service-accounting-service", AccountingSecret, "127.0.13.7");
         var pricing = await LoginAsync(client, "service-pricing-service", PricingSecret, "127.0.13.8");
         var material = await LoginAsync(client, "service-material-service", MaterialSecret, "127.0.13.9");
+        var lifecycle = await LoginAsync(client, "service-lifecycle-service", LifecycleSecret, "127.0.13.10");
 
         Assert.Equal(HttpStatusCode.OK, auth.StatusCode);
         Assert.Equal(HttpStatusCode.OK, contact.StatusCode);
@@ -115,6 +118,7 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         Assert.Equal(HttpStatusCode.OK, accounting.StatusCode);
         Assert.Equal(HttpStatusCode.OK, pricing.StatusCode);
         Assert.Equal(HttpStatusCode.OK, material.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, lifecycle.StatusCode);
 
         await AssertCanonicalServiceTokenAsync(
             search,
@@ -168,6 +172,12 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
                 "iam.auth.check-permission",
                 "supplier.suppliers.read"
             ]);
+        await AssertCanonicalServiceTokenAsync(
+            lifecycle,
+            TestWebApplicationFactory.LifecycleServiceIamPrincipalId,
+            "service-lifecycle-service",
+            "LifecycleService",
+            "roles.workloads.lifecycle-service.v1");
     }
 
     [Fact]
@@ -185,10 +195,10 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
                 .Select(peer => (client.ClientId, peer.Secret)))
             .ToArray();
 
-        Assert.Equal(27, rows.Length);
+        Assert.Equal(30, rows.Length);
         Assert.All(rows, row => Assert.InRange(row.WrongSecrets.Length, 2, 3));
-        Assert.Equal(72, actualPairs.Length);
-        Assert.Equal(72, actualPairs.Distinct().Count());
+        Assert.Equal(90, actualPairs.Length);
+        Assert.Equal(90, actualPairs.Distinct().Count());
         Assert.Equal(
             expectedPairs.OrderBy(pair => pair.ClientId).ThenBy(pair => pair.Secret),
             actualPairs.OrderBy(pair => pair.ClientId).ThenBy(pair => pair.Secret));
@@ -301,6 +311,14 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "MaterialService",
             true,
             (MaterialSecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
+        await SeedManagedCredentialAsync(
+            "service-lifecycle-service",
+            "lifecycle-service",
+            "roles.workloads.lifecycle-service.v1",
+            TestWebApplicationFactory.LifecycleServiceIamPrincipalId,
+            "LifecycleService",
+            true,
+            (LifecycleSecret, ServiceCredentialVersionStatus.Active, DateTimeOffset.UtcNow.AddHours(1), null));
     }
 
     private static async Task AssertCanonicalServiceTokenAsync(

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -63,6 +63,8 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
         Guid.Parse("18181818-1818-1818-1818-181818181818");
     public static readonly Guid MaterialServiceIamPrincipalId =
         Guid.Parse("19191919-1919-1919-1919-191919191919");
+    public static readonly Guid LifecycleServiceIamPrincipalId =
+        Guid.Parse("20202020-2020-2020-2020-202020202020");
 
     public int IamResolutionCalls => Volatile.Read(ref _iamResolutionCalls);
     public int LegacyIamResolutionCalls => Volatile.Read(ref _legacyIamResolutionCalls);
@@ -564,6 +566,27 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                               "principalId": "{{principalId}}",
                               "permissions": ["iam.auth.check-permission", "supplier.suppliers.read"],
                               "roles": ["roles.workloads.material-service.v1"],
+                              "resourcePath": null,
+                              "cacheUntil": null,
+                              "fromCache": false
+                            }
+                            """)
+                    };
+                }
+
+                if (string.Equals(
+                    principalId,
+                    LifecycleServiceIamPrincipalId.ToString(),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            $$"""
+                            {
+                              "principalId": "{{principalId}}",
+                              "permissions": ["iam.auth.check-permission"],
+                              "roles": ["roles.workloads.lifecycle-service.v1"],
                               "resourcePath": null,
                               "cacheUntil": null,
                               "fromCache": false


### PR DESCRIPTION
## Outcome
Extends the managed-service login contract for the canonical LifecycleService credential in MALIEV-Co-Ltd/maliev-ops#99.

- client: `service-lifecycle-service`
- IAM principal: `20202020-2020-2020-2020-202020202020`
- service claim: `LifecycleService`
- role: `roles.workloads.lifecycle-service.v1`
- exact default authority: `iam.auth.check-permission`
- all crossed workload client/secret combinations remain fail-closed with HTTP 401

## TDD evidence
- RED: 1 failed / 36 passed before the Lifecycle IAM resolution fixture existed; the token exposed fallback auth permissions instead of the workload authority
- GREEN: 37/37 focused managed-service login contract tests passed

## Verification
- Release build: 0 warnings, 0 errors
- full tests: 449/449 passed
- `dotnet format --verify-no-changes`: clean
- transitive dependency vulnerability audit: no vulnerable packages

## Dependency and boundary
Depends on MALIEV-Co-Ltd/Maliev.IAMService#32 and must merge after it. This PR changes AuthService contract coverage only. It does not deploy services, enable ArgoCD applications, or modify GitOps.