### PR TITLE
test(auth): align MaterialService supplier authority

### DIFF
--- a/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
+++ b/Maliev.AuthService.Tests/Contract/ManagedServiceLoginContractTests.cs
@@ -170,8 +170,9 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
             "roles.workloads.material-service.v1",
             [
                 "iam.auth.check-permission",
-                "supplier.suppliers.read"
-            ]);
+                "supplier.supplier-references.read"
+            ],
+            ["supplier.suppliers.read"]);
         await AssertCanonicalServiceTokenAsync(
             lifecycle,
             TestWebApplicationFactory.LifecycleServiceIamPrincipalId,
@@ -327,7 +328,8 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         string clientId,
         string serviceName,
         string roleId,
-        string[]? expectedPermissions = null)
+        string[]? expectedPermissions = null,
+        string[]? forbiddenPermissions = null)
     {
         var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         var token = new JwtSecurityTokenHandler().ReadJwtToken(
@@ -338,6 +340,12 @@ public sealed class ManagedServiceLoginContractTests(TestWebApplicationFactory f
         Assert.Equal(
             expectedPermissions ?? ["iam.auth.check-permission"],
             token.Claims.Where(claim => claim.Type == "permissions").Select(claim => claim.Value));
+        foreach (var forbiddenPermission in forbiddenPermissions ?? [])
+        {
+            Assert.DoesNotContain(
+                forbiddenPermission,
+                token.Claims.Where(claim => claim.Type == "permissions").Select(claim => claim.Value));
+        }
         Assert.Equal(
             [roleId],
             token.Claims.Where(claim => claim.Type == "roles").Select(claim => claim.Value));

--- a/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
+++ b/Maliev.AuthService.Tests/Contract/TestWebApplicationFactory.cs
@@ -564,7 +564,7 @@ public class TestWebApplicationFactory : BaseIntegrationTestFactory<Program, Aut
                             $$"""
                             {
                               "principalId": "{{principalId}}",
-                              "permissions": ["iam.auth.check-permission", "supplier.suppliers.read"],
+                              "permissions": ["iam.auth.check-permission", "supplier.supplier-references.read"],
                               "roles": ["roles.workloads.material-service.v1"],
                               "resourcePath": null,
                               "cacheUntil": null,


### PR DESCRIPTION
## Outcome
Aligns AuthService's canonical MaterialService managed-login contract with the current IAM profile tracked by MALIEV-Co-Ltd/maliev-ops#97 and MALIEV-Co-Ltd/maliev-ops#71.

- expected authority is exactly `iam.auth.check-permission` plus `supplier.supplier-references.read`
- obsolete broad `supplier.suppliers.read` is explicitly forbidden
- production AuthService code is unchanged; the drift was limited to the fake IAM response and token assertion

## TDD evidence
- baseline: 37/37 managed-service contract tests passed with the stale contract
- RED: canonical managed-login test failed 1/1, expected `supplier.supplier-references.read` but received `supplier.suppliers.read`
- GREEN: focused managed-service contract tests 37/37

## Full verification
- Release build: 0 warnings, 0 errors
- full tests: 449/449
- `dotnet format --verify-no-changes`: clean
- transitive dependency vulnerability audit: no vulnerable packages

## Boundary
No production runtime, credential, workflow, GitOps, Argo application, or deployment changes.