### PR TITLE
Decouple validation from deployment

### DIFF
--- a/.github/workflows/_validate.yml
+++ b/.github/workflows/_validate.yml
@@ -1,0 +1,35 @@
+name: Reusable Validation
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore Maliev.AuthService.sln
+
+      - name: Audit NuGet dependencies
+        run: dotnet list Maliev.AuthService.sln package --vulnerable --include-transitive
+
+      - name: Build
+        run: dotnet build Maliev.AuthService.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Maliev.AuthService.sln --configuration Release --no-restore --no-build --verbosity normal

--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -2,44 +2,15 @@ name: CI - Develop
 
 on:
   push:
-    branches:
-      - develop
+    branches: [develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auth-service-develop-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-
-    - name: Set up .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '9.0.x'
-
-    - name: Restore dependencies
-      run: dotnet restore Maliev.AuthService.sln
-      working-directory: ${{ github.workspace }}
-
-    - name: Build
-      run: dotnet build Maliev.AuthService.sln --no-restore
-
-    - name: Test
-      run: dotnet test Maliev.AuthService.sln --no-build --verbosity normal
-
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v1
-      with:
-        credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-    - name: Set up Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
-      with:
-        project_id: maliev-website
-
-    - name: Build and push Docker image
-      run: |
-        gcloud auth configure-docker asia-southeast1-docker.pkg.dev
-        docker build -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-dev/maliev-authservice:${{ github.sha }} -f Maliev.AuthService.Api/Dockerfile .
-        docker push asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-dev/maliev-authservice:${{ github.sha }}
+  validate:
+    uses: ./.github/workflows/_validate.yml

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,45 +1,16 @@
-name: CI - Main to Production
+name: CI - Main
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auth-service-main-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-
-    - name: Set up .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '9.0.x'
-
-    - name: Restore dependencies
-      run: dotnet restore Maliev.AuthService.sln
-
-    - name: Build
-      run: dotnet build Maliev.AuthService.sln --no-restore
-
-    - name: Test
-      run: dotnet test Maliev.AuthService.sln --no-build --verbosity normal
-      working-directory: ${{ github.workspace }}
-
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v1
-      with:
-        credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-    - name: Set up Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
-      with:
-        project_id: maliev-website
-
-    - name: Build and push Docker image
-      run: |
-        gcloud auth configure-docker asia-southeast1-docker.pkg.dev
-        docker build -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-prod/maliev-authservice:${{ github.sha }} -f Maliev.AuthService.Api/Dockerfile .
-        docker push asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-prod/maliev-authservice:${{ github.sha }}
+  validate:
+    uses: ./.github/workflows/_validate.yml

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -1,46 +1,16 @@
-name: Release Candidate to Staging
+name: CI - Release Candidate
 
 on:
   push:
-    tags:
-      - 'release/v*'
+    tags: ['release/v*']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auth-service-release-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-
-    - name: Set up .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '9.0.x'
-
-    - name: Restore dependencies
-      run: dotnet restore Maliev.AuthService.sln
-
-    - name: Build
-      run: dotnet build Maliev.AuthService.sln --no-restore
-
-    - name: Test
-      run: dotnet test Maliev.AuthService.sln --no-build --verbosity normal
-      working-directory: ${{ github.workspace }}
-
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v1
-      with:
-        credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-    - name: Set up Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
-      with:
-        project_id: maliev-website
-
-    - name: Build and push Docker image
-      run: |
-        gcloud auth configure-docker asia-southeast1-docker.pkg.dev
-        export RELEASE_VERSION=$(echo ${{ github.ref }} | sed -e 's,.*/v,,g')
-        docker build -t asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-staging/maliev-authservice:$RELEASE_VERSION -f Maliev.AuthService.Api/Dockerfile .
-        docker push asia-southeast1-docker.pkg.dev/maliev-website/maliev-website-artifact-staging/maliev-authservice:$RELEASE_VERSION
+  validate:
+    uses: ./.github/workflows/_validate.yml

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,16 @@
+name: Pull Request Validation
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auth-service-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    uses: ./.github/workflows/_validate.yml

--- a/Maliev.AuthService.Tests/Workflows/WorkflowContractTests.cs
+++ b/Maliev.AuthService.Tests/Workflows/WorkflowContractTests.cs
@@ -1,0 +1,90 @@
+namespace Maliev.AuthService.Tests.Workflows;
+
+using System;
+using System.IO;
+using Xunit;
+
+public sealed class WorkflowContractTests
+{
+    private static readonly string Root = FindRoot();
+    private static readonly string Workflows = Path.Combine(Root, ".github", "workflows");
+
+    [Fact]
+    public void PullRequests_UseCredentialFreeValidation()
+    {
+        var text = Read("pr-validation.yml");
+        Assert.Contains("pull_request:", text);
+        Assert.DoesNotContain("paths:", text);
+        Assert.Contains("contents: read", text);
+        Assert.Contains("uses: ./.github/workflows/_validate.yml", text);
+        AssertSafe(text);
+    }
+
+    [Theory]
+    [InlineData("ci-main.yml", "main")]
+    [InlineData("ci-develop.yml", "develop")]
+    [InlineData("ci-staging.yml", "release/v*")]
+    public void BranchAndTagWorkflows_AreValidationOnly(string file, string trigger)
+    {
+        var text = Read(file);
+        Assert.Contains(trigger, text);
+        Assert.Contains("uses: ./.github/workflows/_validate.yml", text);
+        AssertSafe(text);
+    }
+
+    [Fact]
+    public void ReusableValidation_IsPinnedAndStable()
+    {
+        var text = Read("_validate.yml");
+        Assert.Contains("workflow_call:", text);
+        Assert.Contains("name: validate", text);
+        Assert.Contains("persist-credentials: false", text);
+        Assert.Contains("actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0", text);
+        Assert.Contains("actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68", text);
+        AssertSafe(text);
+    }
+
+    [Fact]
+    public void AllWorkflows_ForbidDeploymentAndPrivilegedTriggers()
+    {
+        foreach (var file in Directory.GetFiles(Workflows, "*.yml"))
+        {
+            var text = File.ReadAllText(file);
+            Assert.DoesNotContain("pull_request_target", text, StringComparison.OrdinalIgnoreCase);
+            AssertSafe(text);
+        }
+    }
+
+    [Fact]
+    public void Documentation_StatesTheValidationOnlyReleaseBoundary()
+    {
+        var readme = File.ReadAllText(Path.Combine(Root, "README.md"));
+        Assert.Contains("No workflow in this repository publishes", readme);
+        Assert.Contains("Aspire owner review", readme);
+    }
+
+    private static void AssertSafe(string text)
+    {
+        foreach (var value in new[] { "secrets.", "id-token: write", "credentials_json", "google-github-actions/auth", "gcloud auth", "docker push", "maliev-gitops", "GITOPS_PAT", "kustomize edit", "gh pr create" })
+        {
+            Assert.DoesNotContain(value, text, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string Read(string file)
+    {
+        var path = Path.Combine(Workflows, file);
+        Assert.True(File.Exists(path), $"Required workflow is missing: {file}");
+        return File.ReadAllText(path);
+    }
+
+    private static string FindRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Maliev.AuthService.sln"))) return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate AuthService repository root.");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ cd Maliev.AuthService.Tests
 dotnet test
 ```
 
+## Validation and Release Boundary
+
+GitHub Actions validates pull requests, `main`, `develop`, and `release/v*`
+tags by restoring and auditing dependencies, building the solution, and running
+the complete test suite.
+
+No workflow in this repository publishes container images, authenticates to
+Google Cloud, modifies GitOps, or deploys to Kubernetes. Release promotion is
+separate and remains pending Aspire owner review. This validation boundary does
+not authorize or perform a production cutover.
+
 ## Key Features
 
 - **Authentication:** Provides endpoints for validating user credentials and generating JWT tokens.


### PR DESCRIPTION
## Summary
- replace credentialed branch/tag deployment workflows with one pinned, read-only validation workflow
- add unfiltered pull-request validation and red-first contracts forbidding cloud auth, image publishing, GitOps mutation, and privileged triggers
- document the Aspire owner-review release boundary

## Validation
- dotnet test Maliev.AuthService.sln --configuration Release --no-restore --verbosity minimal — 20/20 passed
- Release build — 0 warnings, 0 errors
- scoped format and actionlint — clean
- NuGet direct/transitive vulnerability audit — clean
- staged Gitleaks scan — no findings

## Release boundary
Auth/token runtime code is untouched. This PR does not publish images, authenticate to Google Cloud, modify GitOps, deploy to GKE, or cut over production. Final deployment remains pending owner Aspire review.

Tracks MALIEV-Co-Ltd/Maliev.Workflows#12.