### PR TITLE
test: refresh AuthService test tooling

### DIFF
--- a/Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj
+++ b/Maliev.AuthService.Tests/Maliev.AuthService.Tests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Fido2" Version="4.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
@@ -26,11 +26,11 @@
     <PackageReference Include="Testcontainers.Redis" Version="4.8.1" />
     <PackageReference Include="Testcontainers.RabbitMq" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Reapplies the compatible intents from stale Dependabot PRs #85/#88 on the converged AuthService tree and includes the current coverlet collector. Updates only Microsoft.NET.Test.Sdk 18.8.1, xunit.runner.visualstudio 3.1.5, and coverlet.collector 10.0.1. Evidence: Release build 0 warnings/errors; 457/457 tests; no vulnerable packages; format/diff checks clean. No runtime or deployment changes.